### PR TITLE
Fix mentality stat modifier display

### DIFF
--- a/back/utils.py
+++ b/back/utils.py
@@ -131,7 +131,7 @@ class DatabaseUtils:
 
     def fetch_mentality(self, staffID):
         morale = self.cursor.execute(f"SELECT Opinion FROM Staff_Mentality_AreaOpinions WHERE StaffID = {staffID}").fetchall()
-        global_mentality = self.cursor.execute(f"SELECT MentalityOpinion FROM Staff_State WHERE StaffID = {staffID}").fetchone()
+        global_mentality = self.cursor.execute(f"SELECT Mentality FROM Staff_State WHERE StaffID = {staffID}").fetchone()
         return [morale, global_mentality]
 
     def fetchDriverNumberDetails(self, driverID):

--- a/front/js/config.js
+++ b/front/js/config.js
@@ -164,7 +164,6 @@ let default_points = ["25", "18", "15", "12", "10", "8", "6", "4", "2", "1", "DN
 let typeStaff_dict = { 0: "fulldriverlist", 1: "fullTechnicalList", 2: "fullEngineerList", 3: "fullAeroList", 4: "fullDirectorList" }
 let mentality_dict = { 0: "enthusiastic", 1: "positive", 2: "neutral", 3: "negative", 4: "demoralized" }
 let teamOrder = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 32, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31];
-const mentality_bonuses = {0: 7, 1: 4, 2: 0, 3: -2, 4: -6}
 
 //transfers
 const f1_teams = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 32]

--- a/front/js/stats.js
+++ b/front/js/stats.js
@@ -16,6 +16,33 @@ function removeStatsDrivers() {
         elem.innerHTML = ""
     })
 }
+/**
+ * For a given Mentality number, return the actual in-game stat modifier
+ * @param {int} mentality number from 0-100
+ */
+function getModifierFromMentality(mentality) {
+    let modifier;
+    if      (mentality < 6)     modifier = -8;
+    else if (mentality < 10)    modifier = -7;
+    else if (mentality < 16)    modifier = -6;
+    else if (mentality < 21)    modifier = -5;
+    else if (mentality < 25)    modifier = -4;
+    else if (mentality < 30)    modifier = -3;
+    else if (mentality < 36)    modifier = -2;
+    else if (mentality < 40)    modifier = -1;
+    else if (mentality < 60)    modifier = 0;
+    else if (mentality < 64)    modifier = 1;
+    else if (mentality < 70)    modifier = 2;
+    else if (mentality < 78)    modifier = 3;
+    else if (mentality < 80)    modifier = 4;
+    else if (mentality < 84)    modifier = 5;
+    else if (mentality < 86)    modifier = 6;
+    else if (mentality < 97)    modifier = 7;
+    else if (mentality <= 100)  modifier = 8;
+    else modifier = 0;
+    
+    return modifier;
+}
 
 /**
  * Places the drivers that the backend fetched on the driver list
@@ -79,10 +106,11 @@ function place_drivers_editStats(driversArray) {
             newDiv.dataset.globalMentality = driver["global_mentality"]
         }
         let mentality = driver["global_mentality"]
-        if (mentality < 2){
+        let modifier = getModifierFromMentality(mentality)
+        if (modifier > 0){
             mentality_ovrSpan.classList.add("mentality-small-ovr-positive")
         }
-        else if (mentality > 2){
+        else if (modifier < 0){
             mentality_ovrSpan.classList.add("mentality-small-ovr-negative")
         }
         newDiv.dataset.marketability = driver["marketability"]
@@ -231,10 +259,11 @@ function place_staff_editStats(staffArray) {
             mentality_ovrSpan.textContent = ovr[1]
         }
         ovrDiv.appendChild(mentality_ovrSpan)
-        if (mentality < 2){
+        let modifier = getModifierFromMentality(mentality);
+        if (modifier >0){
             mentality_ovrSpan.classList.add("mentality-small-ovr-positive")
         }
-        else if (mentality > 2){
+        else if (modifier < 0){
             mentality_ovrSpan.classList.add("mentality-small-ovr-negative")
         }
         ovrDiv.appendChild(ovrSpan)
@@ -335,7 +364,7 @@ function calculateOverall(stats, type, mentality=2, ovr="small") {
     let statsArray = stats.split(" ").map(Number);
     let mentality_stats = [];
     for (let i = 0; i < statsArray.length; i++) {
-        mentality_stats[i] = statsArray[i] + mentality_bonuses[mentality];
+        mentality_stats[i] = statsArray[i] + getModifierFromMentality(mentality);
     }
     let rating, mentality_rating;
     if (type === "driver") {
@@ -739,13 +768,13 @@ function manage_mentality_modifiers(element, mentality) {
     if (modifier_span){
         modifier_span.remove()
     }
-    let modifier = mentality_bonuses[mentality];
+    let modifier = getModifierFromMentality(mentality);
     let mentality_class, span = "";
-    if (parseInt(mentality) < 2){
+    if (modifier > 0){
         mentality_class = "positive"
         span = "<span class='mentality-modifier positive'> +" + modifier + "</span>"
     }
-    else if (parseInt(mentality) > 2){
+    else if (modifier < 0){
         mentality_class = "negative"
         span = "<span class='mentality-modifier negative'>" + modifier + "</span>"
     }
@@ -909,8 +938,8 @@ function manage_stats_title(html) {
 }
 
 /**
- * Changes the input number that are taken into account to change stats 
- * @param {div} divID div that contains the correct input numbers  
+ * Changes the input number that are taken into account to change stats
+ * @param {div} divID div that contains the correct input numbers
  */
 function change_elegibles(divID) {
     document.querySelectorAll(".elegible").forEach(function (elem) {


### PR DESCRIPTION
I'd like firstly say I have no real SQL/python/javascript experience beyond a few courses from college more than a decade ago.  So I apologize in advance for any mistakes, I am fumbling around in the dark quite a bit here.

Currently when viewing staff attributes, the attribute modifiers from Mentality that are shown are not accurate.  From my extensive testing, by viewing staff attributes values in game (which are inclusive of the mentality stat modifiers), then subtracting what DatabaseEditor reports for the base attribute values to get the actual stat modifier value, and then referencing the Mentality value (0-100) in the Staff.State database, I was able to determine the precise cutoff points for Mentality ranges and the corresponding stat modifier from Mentality:

| Mentality Range | Stat Modifier |
| ------------- | ------------- |
| 97-100 | +8  |
| 86-96 | +7 |
| 84-85 | +6 |
| 80-83 | +5 |
| 78-79 | +4 |
| 70-77 | +3 |
| 64-69 | +2 |
| 60-63 | +1 |
| 40-59 | 0 |
| 36-39 | -1 |
| 30-35 | -2 |
| 25-29 | -3 |
| 21-24 | -4 |
| 16-20 | -5 |
| 10-15 | -6 |
| 6-9 | -7 |
| 0-5| -8 |

I did see on several very rare occasions that the stat modifier did not apply to every single stat (for example, I saw a driver that was supposed to get 0 modifier actually have a +1 to Cornering and a -1 some other stat, but the average was still 0).  I don't see any easy way to for DatabaseEditor to account for those cases, and since they are so rare I figure it is not worth chasing that corner case.