### PR TITLE
Add editing mode for news articles

### DIFF
--- a/src/js/frontend/news.js
+++ b/src/js/frontend/news.js
@@ -2397,8 +2397,9 @@ function createEditFooterButtons(articleEl) {
   cancelArticleBtn.classList.add('close-modal');
   cancelArticleBtn.textContent = 'Cancel';
 
-  buttonsWrapper.appendChild(saveArticleBtn);
   buttonsWrapper.appendChild(cancelArticleBtn);
+  buttonsWrapper.appendChild(saveArticleBtn);
+  
 
   cancelArticleBtn.addEventListener('click', () => exitArticleEditMode());
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -876,7 +876,8 @@ input[type="checkbox"]:focus {
 .parts-list::-webkit-scrollbar,
 .engine-modal-body::-webkit-scrollbar,
 .news-article::-webkit-scrollbar,
-.main-second-viewer::-webkit-scrollbar {
+.main-second-viewer::-webkit-scrollbar,
+.news-edit-textarea::-webkit-scrollbar {
   width: 4px;
 }
 
@@ -892,7 +893,8 @@ input[type="checkbox"]:focus {
 .parts-list::-webkit-scrollbar-thumb,
 .engine-modal-body::-webkit-scrollbar-thumb,
 .news-article::-webkit-scrollbar-thumb,
-.main-second-viewer::-webkit-scrollbar-thumb {
+.main-second-viewer::-webkit-scrollbar-thumb,
+.news-edit-textarea::-webkit-scrollbar-thumb {
   background-color: var(--white-general);
   border-radius: 3px;
 }
@@ -909,7 +911,8 @@ input[type="checkbox"]:focus {
 .parts-list::-webkit-scrollbar-thumb:hover,
 .engine-modal-body::-webkit-scrollbar-thumb:hover,
 .news-article::-webkit-scrollbar-thumb:hover,
-.main-second-viewer::-webkit-scrollbar-thumb:hover {
+.main-second-viewer::-webkit-scrollbar-thumb:hover,
+.news-edit-textarea::-webkit-scrollbar-thumb:hover {
   background-color: var(--scrollbar-hover);
 }
 
@@ -13359,6 +13362,10 @@ body.default-theme .news-article-date {
   gap: 12px;
 }
 
+.news-article:has(.news-edit-textarea){
+  padding-right: 0;
+}
+
 .modal-content {
   background-color: var(--generals) !important;
   /* evita el “hairline” durante la animación */
@@ -13391,6 +13398,8 @@ body.default-theme .news-article-date {
   border: none;
   resize: none;
   width: 100%;
+  height: 100%;
+  padding-right: 10px;
   min-height: 320px;
   color: var(--text-general);
   font: inherit;


### PR DESCRIPTION
## Summary
- add inline edit mode to news modal to toggle markdown textarea and save updates
- replace modal footer buttons with save and cancel controls while editing
- style the edit textarea to appear transparent and non-resizable

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694142aa1d488332a0a4d6a47c545965)