### PR TITLE
Refactor calendar data flow

### DIFF
--- a/src/js/backend/scriptUtils/dbUtils.js
+++ b/src/js/backend/scriptUtils/dbUtils.js
@@ -1886,30 +1886,6 @@ export function calculateTimeDifference(driverID, raceID) {
 
 
 
-export function fetchCalendar() {
-  // Saco [ Day, CurrentSeason ] de Player_State
-  const daySeason = queryDB(`
-      SELECT Day, CurrentSeason
-      FROM Player_State
-    `, [], 'singleRow');
-
-  if (!daySeason) {
-    console.warn("No data found in Player_State.");
-    return [];
-  }
-
-  const [day, currentSeason] = daySeason;
-
-  // Saco el calendario
-  const calendar = queryDB(`
-      SELECT TrackID, WeatherStatePractice, WeatherStateQualifying, WeatherStateRace, WeekendType, State
-      FROM Races
-      WHERE SeasonID = ?
-    `, [currentSeason], 'allRows');
-
-  return calendar;
-}
-
 export function fetchDriverNumbers() {
   const numbers = queryDB(`SELECT DISTINCT Number
        FROM Staff_DriverNumbers dn 

--- a/src/js/backend/worker.js
+++ b/src/js/backend/worker.js
@@ -1,6 +1,6 @@
 import {
   fetchSeasonResults, fetchEventsFrom, fetchTeamsStandings,
-  fetchDrivers, fetchStaff, fetchEngines, fetchCalendar, fetchYear, fetchDriverNumbers, checkCustomTables, checkYearSave,
+  fetchDrivers, fetchStaff, fetchEngines, fetchYear, fetchDriverNumbers, checkCustomTables, checkYearSave,
   fetchOneDriverSeasonResults, fetchOneTeamSeasonResults, fetchEventsDoneFrom, updateCustomEngines, fetchDriversPerYear, fetchDriverContract,
   editEngines, updateCustomConfig, fetchCustomConfig,
   fetch2025ModData, check2025ModCompatibility,
@@ -14,7 +14,7 @@ import { editTeam, fetchTeamData } from "./scriptUtils/editTeamUtils";
 import { overwritePerformanceTeam, updateItemsForDesignDict, fitLoadoutsDict, getPartsFromTeam, getUnitValueFromParts, getAllPartsFromTeam, getMaxDesign, getUnitValueFromOnePart } from "./scriptUtils/carAnalysisUtils";
 import { setGlobals, getGlobals } from "./commandGlobals";
 import { editAge, editMarketability, editName, editRetirement, editSuperlicense, editCode, editMentality, editStats } from "./scriptUtils/eidtStatsUtils";
-import { editCalendar } from "./scriptUtils/calendarUtils";
+import { editCalendar, fetchCalendar } from "./scriptUtils/calendarUtils";
 import { fireDriver, hireDriver, swapDrivers, editContract, futureContract } from "./scriptUtils/transferUtils";
 import { change2024Standings, changeDriverLineUps, changeStats, removeFastestLap, timeTravelWithData, manageAffiliates, changeRaces, manageStandings, insertStaff, manageFeederSeries, changeDriverEngineerPairs, updatePerofmrnace2025, fixes_mod } from "./scriptUtils/modUtils";
 import {
@@ -313,7 +313,7 @@ const workerCommands = {
   },
   editCalendar: (data, postMessage) => {
     const year = getGlobals().yearIteration;
-    editCalendar(data.calendarCodes, year, data.racesData);
+    editCalendar(year, data.racesData);
     postMessage({
       responseMessage: "Calendar updated",
       noti_msg: "Succesfully updated the calendar",

--- a/src/js/frontend/calendar.js
+++ b/src/js/frontend/calendar.js
@@ -28,9 +28,21 @@ function reubicate(div0,div1,beforeAfter) {
 
 /**
  * Adds a race in the calendar div
- * @param {string} code Code from the race
+ * @param {Object} race
  */
-function addRace(code, rainP, rainQ, rainR, type, trackID, state) {
+function addRace(race) {
+    const {
+        code,
+        rainP,
+        rainQ,
+        rainR,
+        type,
+        trackId,
+        state,
+        isF2Race = 0,
+        isF3Race = 0,
+    } = race;
+
     let imageUrl = codes_dict[code];
 
     let div = document.createElement('div');
@@ -41,12 +53,14 @@ function addRace(code, rainP, rainQ, rainR, type, trackID, state) {
     let rightDiv = document.createElement('div');
     rightDiv.className = "right-race"
     div.classList.add('race-calendar');
-    div.dataset.trackid = trackID
+    div.dataset.trackid = trackId
     div.dataset.rainQ = rainQ
     div.dataset.rainR = rainR
     div.dataset.rainP = rainP
     div.dataset.type = type
     div.dataset.state = state
+    div.dataset.isf2 = isF2Race
+    div.dataset.isf3 = isF3Race
     if(state === 2){
         div.classList.add("completed")
         let compDiv = document.createElement('div');
@@ -57,6 +71,29 @@ function addRace(code, rainP, rainQ, rainR, type, trackID, state) {
         divText.style.fontSize = "18px"
         compDiv.appendChild(divText)
         div.appendChild(compDiv)
+    }
+
+    const seriesBadges = document.createElement('div');
+    seriesBadges.className = "race-series-badges";
+
+    if (Number(isF2Race) === 1) {
+        const f2Badge = document.createElement('button');
+        f2Badge.className = "race-series-badge race-series-badge-f2 bold-font";
+        f2Badge.type = "button";
+        f2Badge.textContent = "F2";
+        seriesBadges.appendChild(f2Badge);
+    }
+
+    if (Number(isF3Race) === 1) {
+        const f3Badge = document.createElement('button');
+        f3Badge.className = "race-series-badge race-series-badge-f3 bold-font";
+        f3Badge.type = "button";
+        f3Badge.textContent = "F3";
+        seriesBadges.appendChild(f3Badge);
+    }
+
+    if (seriesBadges.childElementCount > 0) {
+        div.appendChild(seriesBadges);
     }
 
     let upperDiv = document.createElement('div');
@@ -115,9 +152,9 @@ function addRace(code, rainP, rainQ, rainR, type, trackID, state) {
     let wSelector = document.createElement('div');
     wSelector.className = "weather-selector"
     let leftArrow = document.createElement('i');
-    leftArrow.className = "bi bi-chevron-left"
+    leftArrow.classList.add("bi", "bi-chevron-left", "new-augment-button", "transparent")
     let rightArrow = document.createElement('i');
-    rightArrow.className = "bi bi-chevron-right"
+    rightArrow.classList.add("bi", "bi-chevron-right", "new-augment-button", "transparent")
     let wVis = document.createElement('div');
     wVis.className = "weather-vis"
     wVis.dataset.value = Number(rainQ)
@@ -200,8 +237,17 @@ function updateVisualizers(){
 export function load_calendar(races){
     document.querySelector('.main-calendar-section').innerHTML = ""
     races.forEach(function(elem){
-        let code = races_map[elem[0]]
-        addRace(code, transformWeather(elem[1]), transformWeather(elem[2]), transformWeather(elem[3]), elem[4], elem[0], elem[5])
+        addRace({
+            code: races_map[elem.trackId],
+            rainP: transformWeather(elem.weatherStatePractice),
+            rainQ: transformWeather(elem.weatherStateQualifying),
+            rainR: transformWeather(elem.weatherStateRace),
+            type: elem.weekendType,
+            trackId: elem.trackId,
+            state: elem.state,
+            isF2Race: elem.isF2Race,
+            isF3Race: elem.isF3Race
+        })
     })
     updateVisualizers()
     update_numbers()
@@ -292,7 +338,17 @@ function listenerRaces() {
     document.querySelectorAll('#addTrackMenu a').forEach(item => {
         item.addEventListener("click",function () {
             if (document.querySelector(".main-calendar-section").childElementCount < max_races) {
-                addRace(item.dataset.code, 0, 0, 0, 0, item.dataset.trackid, 0)
+                addRace({
+                    code: item.dataset.code,
+                    rainP: 0,
+                    rainQ: 0,
+                    rainR: 0,
+                    type: 0,
+                    trackId: item.dataset.trackid,
+                    state: 0,
+                    isF2Race: 0,
+                    isF3Race: 0
+                })
                 updateVisualizers()
                 update_numbers()
             }

--- a/src/js/frontend/renderer.js
+++ b/src/js/frontend/renderer.js
@@ -552,8 +552,7 @@ function editModeHandler() {
 }
 
 function calendarModeHandler() {
-    let dataCodesString = '';
-    let raceArray = [];
+    const raceArray = [];
 
     document.querySelectorAll(".race-calendar").forEach((race) => {
         let raceData = {
@@ -562,15 +561,14 @@ function calendarModeHandler() {
             rainQuali: race.dataset.rainQ.toString(),
             rainRace: race.dataset.rainR.toString(),
             type: race.dataset.type.toString(),
-            state: race.dataset.state.toString()
+            state: race.dataset.state.toString(),
+            isF2Race: race.dataset.isf2 ? Number(race.dataset.isf2) : 0,
+            isF3Race: race.dataset.isf3 ? Number(race.dataset.isf3) : 0,
         };
         raceArray.push(raceData);
-        dataCodesString += race.dataset.trackid.toString() + race.dataset.rainP.toString() + race.dataset.rainQ.toString() + race.dataset.rainR.toString() + race.dataset.type.toString() + race.dataset.state.toString() + ' ';
     });
 
-    dataCodesString = dataCodesString.trim();
     let dataCalendar = {
-        calendarCodes: dataCodesString,
         racesData: raceArray
     };
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -4430,6 +4430,49 @@ phm
   border: none;
 }
 
+.race-series-badges {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  display: flex;
+  gap: 6px;
+  z-index: 2;
+}
+
+.race-series-badge {
+  border: none;
+  border-radius: 6px;
+  padding: 2px 8px;
+  font-size: 12px;
+  background-color: transparent;
+  cursor: default;
+  transition: background-color 0.15s, color 0.15s, transform 0.15s;
+}
+
+.race-series-badge:active {
+  transform: scale(0.96);
+}
+
+.race-series-badge-f2 {
+  color: var(--f2-border);
+  background-color: color-mix(in srgb, var(--f2-border) 70%, transparent);
+}
+
+.race-series-badge-f2:hover {
+  background-color: color-mix(in srgb, var(--f2-border) 85%, transparent);
+  color: var(--f2-border);
+}
+
+.race-series-badge-f3 {
+  color: var(--f3-border);
+  background-color: color-mix(in srgb, var(--f3-border) 70%, transparent);
+}
+
+.race-series-badge-f3:hover {
+  background-color: color-mix(in srgb, var(--f3-border) 85%, transparent);
+  color: var(--f3-border);
+}
+
 .race-calendar-number {
   border-right: 2px solid var(--separator);
   font-size: 30px;


### PR DESCRIPTION
## Summary
- move calendar fetching into calendar utils and return structured race objects
- update frontend calendar rendering to consume structured race data and simplify save payload
- align calendar edit handling with the new race object shape across worker and backend logic

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949287608348332be38b5d1ab1233b2)