### PR TITLE
Add extra-context modal and hover context button for news articles

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1195,6 +1195,24 @@
       </div>
     </div>
   </div>
+  <div class="modal custom-modal fade" id="newsContextModal" data-bs-backdrop="static" data-bs-keyboard="false">
+    <div class="modal-dialog modal-dialog-sm modal-dialog-centered" role="document">
+      <div class="modal-content custom-modal">
+        <div class="modal-header custom-header">
+          <h3 class="modal-title bold-font">Add context for this article</h3>
+        </div>
+        <div class="modal-body custom-body">
+          <textarea class="news-context-textarea" placeholder="Add extra context for the model..."></textarea>
+        </div>
+        <div class="modal-footer custom-footer">
+          <div class="d-flex">
+            <button type="button" class="close-modal context-cancel" data-bs-dismiss="modal">Cancel</button>
+            <button type="button" class="confirm-modal context-confirm">Read</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
   <div class="modal custom-modal fade" id="compDataModal" data-bs-backdrop="static" data-bs-keyboard="false">
     <div class="modal-dialog modal-dialog-lg modal-dialog-centered" role="document">
       <div class="modal-content custom-modal">

--- a/src/js/frontend/news.js
+++ b/src/js/frontend/news.js
@@ -24,6 +24,7 @@ let interval2 = null;
 let cleaning = false;
 
 let currentModalNews = null;
+let currentModalExtraContext = '';
 let isEditingArticle = false;
 let originalArticleHTML = '';
 let editTextarea = null;
@@ -243,72 +244,128 @@ function hashStr(str) {
 const BUCKET_TURNING = 5;
 const BUCKET_NORMAL = 7;
 
-function addReadButtonListener(readButton, newsItem, news, newsList) {
-  readButton.addEventListener('click', async () => {
-    exitArticleEditMode();
-    currentModalNews = news;
-    newsItem.classList.add('with-transition', 'opened');
-    const newsModal = new bootstrap.Modal(document.getElementById('newsModal'), {
-      keyboard: false
-    });
+async function openContextModal(articleTitle = '') {
+  const modalEl = document.getElementById('newsContextModal');
+  if (!modalEl) return { confirmed: false, context: '' };
 
-    if (!news.text) {
-      newsOptionsBtn.classList.add('d-none');
-    }
-    else {
-      newsOptionsBtn.classList.remove('d-none');
-    }
+  const bsModal =
+    bootstrap.Modal.getInstance(modalEl) ||
+    new bootstrap.Modal(modalEl, { keyboard: false });
 
-    newsModal._element.setAttribute("data-article-id", news.id || '');
+  const modalTitle = modalEl.querySelector('.modal-title');
+  const textarea = modalEl.querySelector('.news-context-textarea');
+  const confirmBtn = modalEl.querySelector('.context-confirm');
+  const cancelBtn = modalEl.querySelector('.context-cancel');
 
-    newsModal.show();
-    const modalTitle = document.querySelector('#newsModal .modal-title');
-    modalTitle.textContent = news.title;
+  if (modalTitle) {
+    modalTitle.textContent = articleTitle
+      ? `Add context for "${articleTitle}"`
+      : "Add context for this article";
+  }
 
-    const newsArticle = document.querySelector('#newsModal .news-article');
-    newsArticle.innerHTML = '';
+  if (textarea) {
+    textarea.value = '';
+  }
 
-    const dateSpan = document.querySelector('#newsModal .news-article-date .dateSpan');
-    const date = excelToDate(news.date);
+  return new Promise((resolve) => {
+    let clicked = false;
+    const controller = new AbortController();
+    const { signal } = controller;
 
-    const day = String(date.getDate()).padStart(2, '0');
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const year = date.getFullYear();
-    dateSpan.textContent = `${day}/${month}/${year}`;
+    confirmBtn?.addEventListener('click', () => {
+      clicked = true;
+      resolve({ confirmed: true, context: textarea?.value?.trim() || '' });
+      bsModal.hide();
+    }, { once: true, signal });
 
-    const image = document.querySelector('#newsModal .news-image-background');
+    cancelBtn?.addEventListener('click', () => {
+      clicked = true;
+      resolve({ confirmed: false, context: '' });
+      bsModal.hide();
+    }, { once: true, signal });
 
-    (async () => {
-      const url = news.image;
-      const exists = await imageExists(url);
+    modalEl.addEventListener('hidden.bs.modal', () => {
+      if (!clicked) resolve({ confirmed: false, context: '' });
+      controller.abort();
+    }, { once: true });
 
-      if (exists) {
-        //remove d-none from image
-        image.classList.remove('d-none');
-        image.src = news.image;
-      } else {
-        //add d-none to image
-        image.classList.add('d-none');
-      }
-    })();
+    modalEl.addEventListener('shown.bs.modal', () => {
+      textarea?.focus();
+    }, { once: true });
 
-    await generateAndRenderArticle(news, newsList, "Generating", false);
-
-    const regenerateButton = document.getElementById('regenerateArticle');
-    if (regenerateButton) {
-      // evitar listeners duplicados si abres varias noticias
-      regenerateButton.replaceWith(regenerateButton.cloneNode(true));
-      const newRegenerateButton = document.getElementById('regenerateArticle');
-
-      newRegenerateButton.addEventListener('click', async () => {
-        await generateAndRenderArticle(news, newsList, "Regenerating", true);
-      });
-    }
-
+    bsModal.show();
   });
 }
 
-async function generateAndRenderArticle(news, newsList, label = "Generating", force = false, model) {
+async function openNewsModalFlow(news, newsItem, newsList, opts = {}) {
+  const { extraContext = '' } = opts;
+  exitArticleEditMode();
+  currentModalNews = news;
+  currentModalExtraContext = extraContext;
+  newsItem?.classList.add('with-transition', 'opened');
+
+  const newsModal = new bootstrap.Modal(document.getElementById('newsModal'), {
+    keyboard: false
+  });
+
+  if (!news.text) {
+    newsOptionsBtn.classList.add('d-none');
+  }
+  else {
+    newsOptionsBtn.classList.remove('d-none');
+  }
+
+  newsModal._element.setAttribute("data-article-id", news.id || '');
+
+  newsModal.show();
+  const modalTitle = document.querySelector('#newsModal .modal-title');
+  modalTitle.textContent = news.title;
+
+  const newsArticle = document.querySelector('#newsModal .news-article');
+  newsArticle.innerHTML = '';
+
+  const dateSpan = document.querySelector('#newsModal .news-article-date .dateSpan');
+  const date = excelToDate(news.date);
+
+  const day = String(date.getDate()).padStart(2, '0');
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const year = date.getFullYear();
+  dateSpan.textContent = `${day}/${month}/${year}`;
+
+  const image = document.querySelector('#newsModal .news-image-background');
+
+  (async () => {
+    const url = news.image;
+    const exists = await imageExists(url);
+
+    if (exists) {
+      image.classList.remove('d-none');
+      image.src = news.image;
+    } else {
+      image.classList.add('d-none');
+    }
+  })();
+
+  await generateAndRenderArticle(news, newsList, "Generating", false, undefined, extraContext);
+
+  const regenerateButton = document.getElementById('regenerateArticle');
+  if (regenerateButton) {
+    regenerateButton.replaceWith(regenerateButton.cloneNode(true));
+    const newRegenerateButton = document.getElementById('regenerateArticle');
+
+    newRegenerateButton.addEventListener('click', async () => {
+      await generateAndRenderArticle(news, newsList, "Regenerating", true, undefined, currentModalExtraContext);
+    });
+  }
+}
+
+function addReadButtonListener(readButton, newsItem, news, newsList) {
+  readButton.addEventListener('click', async () => {
+    await openNewsModalFlow(news, newsItem, newsList);
+  });
+}
+
+async function generateAndRenderArticle(news, newsList, label = "Generating", force = false, model, extraContext = '') {
   exitArticleEditMode();
   const newsArticle = document.querySelector('#newsModal .news-article');
   newsArticle.innerHTML = '';
@@ -346,7 +403,7 @@ async function generateAndRenderArticle(news, newsList, label = "Generating", fo
   }, 150);
 
   try {
-    const articleText = await manageRead(news, newsList, progressDiv, interval, { force });
+    const articleText = await manageRead(news, newsList, progressDiv, interval, { force, extraContext });
 
     clearInterval(interval);
     clearInterval(dotsInterval);
@@ -611,6 +668,16 @@ function createNewsItemElement(news, index, newsAvailable, newsList, maxDate, is
   const readbuttonContainer = document.createElement('div');
   readbuttonContainer.classList.add('read-button-container');
 
+  const readActions = document.createElement('div');
+  readActions.classList.add('read-actions');
+
+  const contextButton = document.createElement('div');
+  contextButton.classList.add('context-read-button');
+  contextButton.setAttribute('title', 'Add context');
+  const contextIcon = document.createElement('i');
+  contextIcon.classList.add('bi', 'bi-chat-text');
+  contextButton.appendChild(contextIcon);
+
   const readButton = document.createElement('div');
   readButton.classList.add('read-button');
   const readButtonSpan = document.createElement('span');
@@ -669,6 +736,11 @@ function createNewsItemElement(news, index, newsAvailable, newsList, maxDate, is
 
 
   addReadButtonListener(readButton, newsItem, news, newsList);
+  contextButton.addEventListener('click', async () => {
+    const result = await openContextModal(news.title);
+    if (!result.confirmed) return;
+    await openNewsModalFlow(news, newsItem, newsList, { extraContext: result.context });
+  });
 
   newsItem.appendChild(imageContainer);
   titleAndArticle.appendChild(newsTitle);
@@ -681,11 +753,15 @@ function createNewsItemElement(news, index, newsAvailable, newsList, maxDate, is
 
   if (!news.nonReadable || news.nonReadable === false) { //first check - if the news is readable
     if (newsAvailable.normal === true && !isTurning) { //second check - if normal news are available
-      readbuttonContainer.appendChild(readButton);
+      readActions.appendChild(contextButton);
+      readActions.appendChild(readButton);
+      readbuttonContainer.appendChild(readActions);
     }
 
     if (newsAvailable.turning === true && isTurning) { //second check - if insider news are available
-      readbuttonContainer.appendChild(readButton);
+      readActions.appendChild(contextButton);
+      readActions.appendChild(readButton);
+      readbuttonContainer.appendChild(readActions);
     }
 
   }
@@ -693,6 +769,7 @@ function createNewsItemElement(news, index, newsAvailable, newsList, maxDate, is
   //if news has .isCurrentSeason and its false, remove read button and turning point buttons
   if (isCurrentSeason === false && (news.text === undefined || news.text === null)) {
     readButton.remove();
+    contextButton.remove();
     const tpDiv = readbuttonContainer.querySelector('.turning-point-div');
     if (tpDiv) tpDiv.remove();
   }
@@ -810,6 +887,16 @@ export async function place_turning_outcome(turningPointResponse, newsList) {
   const readbuttonContainer = document.createElement('div');
   readbuttonContainer.classList.add('read-button-container');
 
+  const readActions = document.createElement('div');
+  readActions.classList.add('read-actions');
+
+  const contextButton = document.createElement('div');
+  contextButton.classList.add('context-read-button');
+  contextButton.setAttribute('title', 'Add context');
+  const contextIcon = document.createElement('i');
+  contextIcon.classList.add('bi', 'bi-chat-text');
+  contextButton.appendChild(contextIcon);
+
   const readButton = document.createElement('div');
   readButton.classList.add('read-button');
   const readButtonSpan = document.createElement('span');
@@ -817,60 +904,22 @@ export async function place_turning_outcome(turningPointResponse, newsList) {
   readButton.appendChild(readButtonSpan);
 
   readButton.addEventListener('click', async () => {
-    exitArticleEditMode();
-    currentModalNews = turningPointResponse;
-    const newsModal = new bootstrap.Modal(document.getElementById('newsModal'), {
-      keyboard: false
-    });
-    newsModal.show();
+    await openNewsModalFlow(turningPointResponse, newsItem, newsList);
+  });
 
-    if (!turningPointResponse.text) {
-      newsOptionsBtn.classList.add('d-none');
-    }
-    else {
-      newsOptionsBtn.classList.remove('d-none');
-    }
-
-    newsModal._element.setAttribute("data-article-id", turningPointResponse.id || '');
-
-    const modalTitle = document.querySelector('#newsModal .modal-title');
-    modalTitle.textContent = turningPointResponse.title;
-
-    const newsArticle = document.querySelector('#newsModal .news-article');
-    newsArticle.innerHTML = '';
-
-
-    const dateSpan = document.querySelector('#newsModal .news-article-date .dateSpan');
-    const date = excelToDate(turningPointResponse.date);
-
-
-    const day = String(date.getDate()).padStart(2, '0');
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const year = date.getFullYear();
-    dateSpan.textContent = `${day}/${month}/${year}`;
-
-    const image = document.querySelector('#newsModal .news-image-background');
-    image.src = turningPointResponse.image;
-
-    await generateAndRenderArticle(turningPointResponse, newsList, "Generating", false);
-
-    // Hook para REGENERAR (misma lógica, forzando)
-    const regenBtn = document.getElementById('regenerateArticle');
-    if (regenBtn) {
-      regenBtn.replaceWith(regenBtn.cloneNode(true)); // evita listeners duplicados
-      const newRegenBtn = document.getElementById('regenerateArticle');
-      newRegenBtn.addEventListener('click', () => {
-        generateAndRenderArticle(turningPointResponse, newsList, "Regenerating", true);
-      });
-    }
-
+  contextButton.addEventListener('click', async () => {
+    const result = await openContextModal(turningPointResponse.title);
+    if (!result.confirmed) return;
+    await openNewsModalFlow(turningPointResponse, newsItem, newsList, { extraContext: result.context });
   });
 
   imageContainer.appendChild(image);
   newsItem.appendChild(imageContainer);
   titleAndArticle.appendChild(newsTitle);
   newsBody.appendChild(titleAndArticle);
-  readbuttonContainer.appendChild(readButton);
+  readActions.appendChild(contextButton);
+  readActions.appendChild(readButton);
+  readbuttonContainer.appendChild(readActions);
   newsBody.appendChild(readbuttonContainer);
   newsItem.appendChild(newsBody);
 
@@ -1271,7 +1320,7 @@ function buildContextualPrompt(data, config = {}) {
 }
 
 async function manageRead(newData, newsList, barProgressDiv, interval, opts = {}) {
-  const { force = false } = opts;
+  const { force = false, extraContext = '' } = opts;
   const stableKey = newData.stableKey ?? newData.id ?? computeStableKey(newData);
 
   // 1) Si ya hay texto y NO forzamos, devolvemos el existente
@@ -1374,6 +1423,13 @@ async function manageRead(newData, newsList, barProgressDiv, interval, opts = {}
         role: "user",
         content: `Here is context about  results, championship standings, driver stats and important events that happened throughout the season:\n\n${context}`
       });
+
+      if (extraContext.trim()) {
+        messages.push({
+          role: "user",
+          content: `Additional context to incorporate:\n${extraContext.trim()}`
+        });
+      }
 
       // Message 2: Instruction
       messages.push({

--- a/src/styles.css
+++ b/src/styles.css
@@ -14521,6 +14521,12 @@ body.default-theme .news-article-date {
   justify-content: space-between;
 }
 
+.read-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  justify-content: flex-end;
+}
 
 .read-button {
   border-radius: 5px;
@@ -14531,6 +14537,56 @@ body.default-theme .news-article-date {
   cursor: pointer;
   position: relative;
   transition: background-color 0.15s, color 0.15s;
+}
+
+.context-read-button {
+  border-radius: 5px;
+  background-color: var(--elements);
+  color: var(--dark-text);
+  align-self: flex-end;
+  padding: 5px 8px;
+  cursor: pointer;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(6px);
+  transition: opacity 0.15s ease, transform 0.15s ease, background-color 0.15s, color 0.15s;
+}
+
+.context-read-button i {
+  font-size: 16px;
+}
+
+.news-item:hover .context-read-button,
+.news-item:focus-within .context-read-button {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateX(0);
+}
+
+.context-read-button:hover {
+  background-color: var(--elements-hover);
+  color: var(--text-general);
+}
+
+.news-context-textarea {
+  width: 100%;
+  min-height: 140px;
+  resize: vertical;
+  border-radius: 8px;
+  border: 1px solid var(--elements-hover);
+  background-color: color-mix(in srgb, var(--elements) 70%, transparent);
+  color: var(--text-general);
+  padding: 8px 10px;
+  outline: none;
+}
+
+.news-context-textarea:focus {
+  border-color: var(--new-primary);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--new-primary) 50%, transparent);
 }
 
 .close-modal,


### PR DESCRIPTION
### Motivation
- Provide a way for users to give extra LLM context before generating a news article so the model can incorporate user-provided details.
- Surface that control as a small hover-only button next to the existing `Read` action for each news item for minimal UI disruption.
- Reuse the existing modal-driven UX (confirm-style flow) so the behavior matches the app's modal interactions.
- Ensure the extra context is passed to both initial generation and regeneration flows so content is consistent.

### Description
- Added a hover-only context button and surrounding container (`.context-read-button`, `.read-actions`) next to the `Read` button in `src/js/frontend/news.js` and styled it in `src/styles.css` to only appear on `.news-item:hover`.
- Introduced a small modal markup `#newsContextModal` in `src/index.html` with a textarea `.news-context-textarea` and wired it to a new `openContextModal` helper that returns `{confirmed, context}`.
- Implemented `openNewsModalFlow` and threaded an `extraContext` parameter through `generateAndRenderArticle` and `manageRead` so the entered context is injected into the AI messages before calling `askGenAI`.
- Updated turning-point and regeneration handlers to use the same context flow and added `currentModalExtraContext` to persist the context for regenerations.

### Testing
- No automated tests were run for this change.
- The patch was linted and files staged/committed in the working tree (no runtime verification performed in this environment).
- Manual runtime testing is recommended to validate modal focus, textarea behavior, hover visibility, and that the LLM prompt receives the additional context.
- Verify regeneration uses the same `extraContext` when clicking `Regenerate` after adding context.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960e89da9ac833283becacd70926f0c)