### PR TITLE
Use team logos in head-to-head headers

### DIFF
--- a/src/js/backend/scriptUtils/head2head.js
+++ b/src/js/backend/scriptUtils/head2head.js
@@ -39,6 +39,9 @@ export function fetchHead2Head(driver1ID, driver2ID, year, isCurrentYear = true)
     polesH2H: [0, 0],
     winsH2H: [0, 0],
     sprintWinsH2H: [0, 0],
+    top10H2H: [0, 0],
+    q3H2H: [0, 0],
+    frontRowH2H: [0, 0],
 
     pointsH2H: null,
     bestRace: null,
@@ -56,7 +59,9 @@ export function fetchHead2Head(driver1ID, driver2ID, year, isCurrentYear = true)
       avgPace: [],
       avgQPace: [],
       RPositions: [],
-      QPositions: []
+      QPositions: [],
+      startPositions: [],
+      posGains: []
     },
     driver2: {
       bestRace: 21,
@@ -64,7 +69,9 @@ export function fetchHead2Head(driver1ID, driver2ID, year, isCurrentYear = true)
       avgPace: [],
       avgQPace: [],
       RPositions: [],
-      QPositions: []
+      QPositions: [],
+      startPositions: [],
+      posGains: []
     }
   };
 
@@ -168,6 +175,18 @@ export function fetchHead2Head(driver1ID, driver2ID, year, isCurrentYear = true)
     if (d2_QRes === 1 && (!isCurrentYear || d2_QStage === 3)) {
       stats.polesH2H[1] += 1;
     }
+    if (d1_QStage === 3) {
+      stats.q3H2H[0] += 1;
+    }
+    if (d2_QStage === 3) {
+      stats.q3H2H[1] += 1;
+    }
+    if (d1_QRes <= 2) {
+      stats.frontRowH2H[0] += 1;
+    }
+    if (d2_QRes <= 2) {
+      stats.frontRowH2H[1] += 1;
+    }
 
     // Mejor qualifying
     if (d1_QRes < stats.driver1.bestQuali) {
@@ -188,6 +207,20 @@ export function fetchHead2Head(driver1ID, driver2ID, year, isCurrentYear = true)
 
     const d2_RRes = queryDB(`
         SELECT FinishingPos
+        FROM Races_Results
+        WHERE RaceID = ?
+          AND Season = ?
+          AND DriverID = ?
+      `, [raceID, year, driver2ID], 'singleValue') || 99;
+    const d1_StartPos = queryDB(`
+        SELECT StartingPos
+        FROM Races_Results
+        WHERE RaceID = ?
+          AND Season = ?
+          AND DriverID = ?
+      `, [raceID, year, driver1ID], 'singleValue') || 99;
+    const d2_StartPos = queryDB(`
+        SELECT StartingPos
         FROM Races_Results
         WHERE RaceID = ?
           AND Season = ?
@@ -220,6 +253,8 @@ export function fetchHead2Head(driver1ID, driver2ID, year, isCurrentYear = true)
     // Guardamos posición de carrera
     stats.driver1.RPositions.push(d1_RRes);
     stats.driver2.RPositions.push(d2_RRes);
+    stats.driver1.startPositions.push(d1_StartPos);
+    stats.driver2.startPositions.push(d2_StartPos);
 
     // --- 3.7) DNFs
     const d1_RDNF = queryDB(`
@@ -240,6 +275,14 @@ export function fetchHead2Head(driver1ID, driver2ID, year, isCurrentYear = true)
 
     if (d1_RDNF === 1) stats.dnfH2H[0] += 1;
     if (d2_RDNF === 1) stats.dnfH2H[1] += 1;
+    if (d1_RDNF !== 1 && d1_RRes <= 10) stats.top10H2H[0] += 1;
+    if (d2_RDNF !== 1 && d2_RRes <= 10) stats.top10H2H[1] += 1;
+    if (d1_RDNF !== 1) {
+      stats.driver1.posGains.push(Number((d1_StartPos - d1_RRes).toFixed(1)));
+    }
+    if (d2_RDNF !== 1) {
+      stats.driver2.posGains.push(Number((d2_StartPos - d2_RRes).toFixed(1)));
+    }
 
     // --- 3.8) Ritmo en carrera (avg pace) si ninguno hizo DNF
     if (d1_RDNF !== 1 && d2_RDNF !== 1) {
@@ -331,6 +374,10 @@ export function fetchHead2Head(driver1ID, driver2ID, year, isCurrentYear = true)
   const meanQd2 = Number(mean(stats.driver2.QPositions).toFixed(1));
   const medianQd1 = median(stats.driver1.QPositions);
   const medianQd2 = median(stats.driver2.QPositions);
+  const meanGrid1 = Number(mean(stats.driver1.startPositions).toFixed(1));
+  const meanGrid2 = Number(mean(stats.driver2.startPositions).toFixed(1));
+  const meanGain1 = Number(mean(stats.driver1.posGains).toFixed(1));
+  const meanGain2 = Number(mean(stats.driver2.posGains).toFixed(1));
 
   const rDifferences = stats.driver1.avgPace.map((val, i) => (stats.driver2.avgPace[i] ?? 0) - val);
   const avg_racediff = Number(mean(rDifferences).toFixed(3));
@@ -355,7 +402,12 @@ export function fetchHead2Head(driver1ID, driver2ID, year, isCurrentYear = true)
     [meanRd1, meanRd2],                      // 12) (meanRd1, meanRd2)
     [medianRd1, medianRd2],                  // 13) (medianRd1, medianRd2)
     [meanQd1, meanQd2],                      // 14) (meanQd1, meanQd2)
-    [medianQd1, medianQd2]                   // 15) (medianQd1, medianQd2)
+    [medianQd1, medianQd2],                  // 15) (medianQd1, medianQd2)
+    [meanGrid1, meanGrid2],                  // 16) (meanGrid1, meanGrid2)
+    [meanGain1, meanGain2],                  // 17) (meanGain1, meanGain2)
+    stats.top10H2H,                          // 18) (top10H2H)
+    stats.q3H2H,                             // 19) (q3H2H)
+    stats.frontRowH2H                        // 20) (frontRowH2H)
   ];
 
   // 4) Retornamos este array en vez de 'stats'
@@ -390,6 +442,9 @@ export function fetchHead2HeadTeam(teamID1, teamID2, year, isCurrentYear = true)
   const polesH2H = [0, 0];
   const winsH2H = [0, 0];
   const sprintWinsH2H = [0, 0];
+  const top10H2H = [0, 0];
+  const q3H2H = [0, 0];
+  const frontRowH2H = [0, 0];
 
   let d1_BestRace = 21;
   let d2_BestRace = 21;
@@ -400,6 +455,14 @@ export function fetchHead2HeadTeam(teamID1, teamID2, year, isCurrentYear = true)
   const d2_avgPace = [];
   const d1_avgQPace = [];
   const d2_avgQPace = [];
+  const d1_RPositions = [];
+  const d2_RPositions = [];
+  const d1_QPositions = [];
+  const d2_QPositions = [];
+  const d1_startPositions = [];
+  const d2_startPositions = [];
+  const d1_posGains = [];
+  const d2_posGains = [];
 
   // 3) Iteramos por cada carrera encontrada
   for (const raceID of raceIDs) {
@@ -536,6 +599,18 @@ export function fetchHead2HeadTeam(teamID1, teamID2, year, isCurrentYear = true)
     if (d2_QRes === 1 && (!isCurrentYear || d2_QStage === 3)) {
       polesH2H[1] += 1;
     }
+    if (d1_QStage === 3) {
+      q3H2H[0] += 1;
+    }
+    if (d2_QStage === 3) {
+      q3H2H[1] += 1;
+    }
+    if (d1_QRes <= 2) {
+      frontRowH2H[0] += 1;
+    }
+    if (d2_QRes <= 2) {
+      frontRowH2H[1] += 1;
+    }
 
     // Best Quali
     if (d1_QRes < d1_BestQauli) {
@@ -561,6 +636,20 @@ export function fetchHead2HeadTeam(teamID1, teamID2, year, isCurrentYear = true)
           AND Season = ?
           AND DriverID IN (${d2Placeholders})
       `, [raceID, season, ...drivers2IDs], 'singleValue') || 99;
+    const d1_StartPos = queryDB(`
+        SELECT MIN(StartingPos)
+        FROM Races_Results
+        WHERE RaceID = ?
+          AND Season = ?
+          AND DriverID IN (${d1Placeholders})
+      `, [raceID, season, ...drivers1IDs], 'singleValue') || 99;
+    const d2_StartPos = queryDB(`
+        SELECT MIN(StartingPos)
+        FROM Races_Results
+        WHERE RaceID = ?
+          AND Season = ?
+          AND DriverID IN (${d2Placeholders})
+      `, [raceID, season, ...drivers2IDs], 'singleValue') || 99;
 
     // Wins
     if (d1_RRes === 1) winsH2H[0] += 1;
@@ -572,10 +661,16 @@ export function fetchHead2HeadTeam(teamID1, teamID2, year, isCurrentYear = true)
     } else if (d1_RRes > d2_RRes) {
       raceH2H[1] += 1;
     }
+    d1_RPositions.push(d1_RRes);
+    d2_RPositions.push(d2_RRes);
+    d1_startPositions.push(d1_StartPos);
+    d2_startPositions.push(d2_StartPos);
 
     // Podios
     if (d1_RRes <= 3) podiumsH2H[0] += 1;
     if (d2_RRes <= 3) podiumsH2H[1] += 1;
+    if (d1_RRes <= 10) top10H2H[0] += 1;
+    if (d2_RRes <= 10) top10H2H[1] += 1;
 
     // Best Race
     if (d1_RRes < d1_BestRace) {
@@ -604,6 +699,12 @@ export function fetchHead2HeadTeam(teamID1, teamID2, year, isCurrentYear = true)
 
     dnfH2H[0] += d1_RDNF;
     dnfH2H[1] += d2_RDNF;
+    if (d1_RDNF === 0) {
+      d1_posGains.push(Number((d1_StartPos - d1_RRes).toFixed(1)));
+    }
+    if (d2_RDNF === 0) {
+      d2_posGains.push(Number((d2_StartPos - d2_RRes).toFixed(1)));
+    }
 
 
     // 3.8) Ritmo de carrera (si al menos un piloto del equipo no hizo DNF)
@@ -666,6 +767,8 @@ export function fetchHead2HeadTeam(teamID1, teamID2, year, isCurrentYear = true)
     if (d2_SRes === 1) {
       sprintWinsH2H[1] += 1;
     }
+    d1_QPositions.push(d1_QRes);
+    d2_QPositions.push(d2_QRes);
   }
 
   // 4) Puntos de cada equipo en el campeonato (TeamStandings)
@@ -714,6 +817,18 @@ export function fetchHead2HeadTeam(teamID1, teamID2, year, isCurrentYear = true)
 
   const avg_racediff = Number(mean(rDifferences).toFixed(3));
   const avg_qualidiff = Number(mean(qDifferences).toFixed(3));
+  const meanRd1 = Number(mean(d1_RPositions).toFixed(1));
+  const meanRd2 = Number(mean(d2_RPositions).toFixed(1));
+  const medianRd1 = median(d1_RPositions);
+  const medianRd2 = median(d2_RPositions);
+  const meanQd1 = Number(mean(d1_QPositions).toFixed(1));
+  const meanQd2 = Number(mean(d2_QPositions).toFixed(1));
+  const medianQd1 = median(d1_QPositions);
+  const medianQd2 = median(d2_QPositions);
+  const meanGrid1 = Number(mean(d1_startPositions).toFixed(1));
+  const meanGrid2 = Number(mean(d2_startPositions).toFixed(1));
+  const meanGain1 = Number(mean(d1_posGains).toFixed(1));
+  const meanGain2 = Number(mean(d2_posGains).toFixed(1));
 
 
   const resultList = [
@@ -728,7 +843,16 @@ export function fetchHead2HeadTeam(teamID1, teamID2, year, isCurrentYear = true)
     polesH2H,
     sprintWinsH2H,
     [-avg_racediff, avg_racediff],
-    [-avg_qualidiff, avg_qualidiff]
+    [-avg_qualidiff, avg_qualidiff],
+    [meanRd1, meanRd2],
+    [medianRd1, medianRd2],
+    [meanQd1, meanQd2],
+    [medianQd1, medianQd2],
+    [meanGrid1, meanGrid2],
+    [meanGain1, meanGain2],
+    top10H2H,
+    q3H2H,
+    frontRowH2H
   ];
 
   // 7) Retornamos el array final

--- a/src/js/frontend/head2head.js
+++ b/src/js/frontend/head2head.js
@@ -1,4 +1,4 @@
-import { races_names, team_dict, combined_dict, lightColors, theme_colors } from "./config";
+import { races_names, team_dict, combined_dict, lightColors, theme_colors, logos_disc } from "./config";
 import { game_version, custom_team, selectedTheme } from "./renderer";
 import { insert_space, manageColor, format_name } from "./transfers";
 import Chart from 'chart.js/auto';
@@ -19,7 +19,8 @@ let poles = false;
 let sprints = false;
 let race = 0;
 let quali = 0;
-let menuLength = 4;
+const raceMenuLength = 7;
+const qualiMenuLength = 6;
 let driverGraph;
 let pointsGraph;
 let qualiGraph;
@@ -40,6 +41,30 @@ let queuedAutoCompareDrivers = null;
 export let mid_grid = 10;
 export let max_races = 23;
 export let relative_grid = 5;
+
+function formatSignedValue(value) {
+    if (value > 0) {
+        return `+${value}`;
+    }
+    return `${value}`;
+}
+
+function renderTeamLogo(container, teamId) {
+    if (!container) return;
+    const logoSrc = logos_disc[teamId];
+    const teamName = combined_dict[teamId] || "";
+    container.innerHTML = "";
+    container.title = teamName;
+    if (!logoSrc) {
+        container.textContent = teamName;
+        return;
+    }
+    const logoImg = document.createElement("img");
+    logoImg.className = "drivers-table-logo team-h2h-logo";
+    logoImg.src = logoSrc;
+    logoImg.alt = teamName;
+    container.appendChild(logoImg);
+}
 
 export function setMidGrid(value) {
     mid_grid = value
@@ -213,6 +238,26 @@ export function manage_h2h_bars(data) {
                         elem.querySelector(".driver1-number").textContent = data[15][0]
                         elem.querySelector(".driver2-number").textContent = data[15][1]
                     }
+                    else if (quali === 4) {
+                        relValue = (100 / (data[19][0] + data[19][1])).toFixed(2)
+                        if (relValue == Infinity) {
+                            relValue = 0
+                        }
+                        d1_width = data[19][0] * relValue
+                        d2_width = data[19][1] * relValue
+                        elem.querySelector(".driver1-number").textContent = data[19][0]
+                        elem.querySelector(".driver2-number").textContent = data[19][1]
+                    }
+                    else if (quali === 5) {
+                        relValue = (100 / (data[20][0] + data[20][1])).toFixed(2)
+                        if (relValue == Infinity) {
+                            relValue = 0
+                        }
+                        d1_width = data[20][0] * relValue
+                        d2_width = data[20][1] * relValue
+                        elem.querySelector(".driver1-number").textContent = data[20][0]
+                        elem.querySelector(".driver2-number").textContent = data[20][1]
+                    }
                 }
 
                 if (elem.id === "raceh2h") {
@@ -236,6 +281,32 @@ export function manage_h2h_bars(data) {
                         d2_width = 100 - (data[13][1] - 1) * relative_grid
                         elem.querySelector(".driver1-number").textContent = data[13][0]
                         elem.querySelector(".driver2-number").textContent = data[13][1]
+                    }
+                    else if (race === 4) {
+                        d1_width = 100 - (data[16][0] - 1) * relative_grid
+                        d2_width = 100 - (data[16][1] - 1) * relative_grid
+                        elem.querySelector(".driver1-number").textContent = data[16][0]
+                        elem.querySelector(".driver2-number").textContent = data[16][1]
+                    }
+                    else if (race === 5) {
+                        let maxGain = Math.max(Math.abs(data[17][0]), Math.abs(data[17][1]))
+                        if (maxGain === 0) {
+                            maxGain = 1
+                        }
+                        d1_width = (Math.abs(data[17][0]) / maxGain) * 100
+                        d2_width = (Math.abs(data[17][1]) / maxGain) * 100
+                        elem.querySelector(".driver1-number").textContent = formatSignedValue(data[17][0])
+                        elem.querySelector(".driver2-number").textContent = formatSignedValue(data[17][1])
+                    }
+                    else if (race === 6) {
+                        relValue = (100 / (data[18][0] + data[18][1])).toFixed(2)
+                        if (relValue == Infinity) {
+                            relValue = 0
+                        }
+                        d1_width = data[18][0] * relValue
+                        d2_width = data[18][1] * relValue
+                        elem.querySelector(".driver1-number").textContent = data[18][0]
+                        elem.querySelector(".driver2-number").textContent = data[18][1]
                     }
                 }
 
@@ -396,6 +467,35 @@ function toggle_racePace() {
             elem.querySelector(".driver1-number").textContent = compData[13][0]
             elem.querySelector(".driver2-number").textContent = compData[13][1]
         }
+        else if (race === 4) {
+            elem.querySelector(".only-name").textContent = "AVG GRID"
+            d1_width = 100 - (compData[16][0] - 1) * 5
+            d2_width = 100 - (compData[16][1] - 1) * 5
+            elem.querySelector(".driver1-number").textContent = compData[16][0]
+            elem.querySelector(".driver2-number").textContent = compData[16][1]
+        }
+        else if (race === 5) {
+            elem.querySelector(".only-name").textContent = "AVG POS GAIN"
+            let maxGain = Math.max(Math.abs(compData[17][0]), Math.abs(compData[17][1]))
+            if (maxGain === 0) {
+                maxGain = 1
+            }
+            d1_width = (Math.abs(compData[17][0]) / maxGain) * 100
+            d2_width = (Math.abs(compData[17][1]) / maxGain) * 100
+            elem.querySelector(".driver1-number").textContent = formatSignedValue(compData[17][0])
+            elem.querySelector(".driver2-number").textContent = formatSignedValue(compData[17][1])
+        }
+        else if (race === 6) {
+            elem.querySelector(".only-name").textContent = "TOP 10s"
+            relValue = (100 / (compData[18][0] + compData[18][1])).toFixed(2)
+            if (relValue == Infinity) {
+                relValue = 0
+            }
+            d1_width = compData[18][0] * relValue
+            d2_width = compData[18][1] * relValue
+            elem.querySelector(".driver1-number").textContent = compData[18][0]
+            elem.querySelector(".driver2-number").textContent = compData[18][1]
+        }
         fill_bars(elem, d1_width, d2_width)
     }
 
@@ -456,6 +556,28 @@ function toggle_qualiPace() {
             elem.querySelector(".driver1-number").textContent = compData[15][0]
             elem.querySelector(".driver2-number").textContent = compData[15][1]
         }
+        else if (quali === 4) {
+            elem.querySelector(".only-name").textContent = "Q3 APPEARANCES"
+            relValue = (100 / (compData[19][0] + compData[19][1])).toFixed(2)
+            if (relValue == Infinity) {
+                relValue = 0
+            }
+            d1_width = compData[19][0] * relValue
+            d2_width = compData[19][1] * relValue
+            elem.querySelector(".driver1-number").textContent = compData[19][0]
+            elem.querySelector(".driver2-number").textContent = compData[19][1]
+        }
+        else if (quali === 5) {
+            elem.querySelector(".only-name").textContent = "FRONT ROWS"
+            relValue = (100 / (compData[20][0] + compData[20][1])).toFixed(2)
+            if (relValue == Infinity) {
+                relValue = 0
+            }
+            d1_width = compData[20][0] * relValue
+            d2_width = compData[20][1] * relValue
+            elem.querySelector(".driver1-number").textContent = compData[20][0]
+            elem.querySelector(".driver2-number").textContent = compData[20][1]
+        }
         fill_bars(elem, d1_width, d2_width)
     }
 }
@@ -504,7 +626,7 @@ export function qualiPaceListener() {
  */
 function increase_racePaceView() {
     race += 1
-    race = race % menuLength
+    race = race % raceMenuLength
     toggle_racePace()
 }
 
@@ -513,7 +635,7 @@ function increase_racePaceView() {
  */
 function decrease_racePaceView() {
     race -= 1
-    race = (race + menuLength) % menuLength
+    race = (race + raceMenuLength) % raceMenuLength
     toggle_racePace()
 }
 
@@ -522,7 +644,7 @@ function decrease_racePaceView() {
  */
 function increase_qualiPaceView() {
     quali += 1
-    quali = quali % menuLength
+    quali = quali % qualiMenuLength
     toggle_qualiPace()
 }
 
@@ -531,7 +653,7 @@ function increase_qualiPaceView() {
  */
 function decrease_qualiPaceView() {
     quali -= 1
-    quali = (quali + menuLength) % menuLength
+    quali = (quali + qualiMenuLength) % qualiMenuLength
     toggle_qualiPace()
 }
 
@@ -830,7 +952,6 @@ document.querySelector("#confirmComparison").addEventListener("click", function 
         document.querySelector("#raceForm").click()
         race = 0
         quali = 0
-        menuLength = 4
         document.getElementById("qualih2h").querySelector(".only-name").innerText = "QUALIFYING"
         document.getElementById("raceh2h").querySelector(".only-name").innerText = "RACE"
         document.getElementById("raceh2h").querySelector(".bar-space").classList.remove("d-none")
@@ -844,7 +965,6 @@ document.querySelector("#confirmComparison").addEventListener("click", function 
         document.querySelector("#gapToWinner").classList.add("d-none")
         document.querySelector("#gapToPole").classList.add("d-none")
         document.querySelector("#pointsProgression").click()
-        menuLength = 2
         race = 0
         quali = 0
         document.getElementById("qualih2h").querySelector(".only-name").innerText = "QUALIFYING"
@@ -968,8 +1088,9 @@ function nameTitleD1(aDriver1) {
         document.querySelector(".driver1-first").classList.add("d-none")
         document.querySelector(".driver1-second").classList.add("d-none")
         document.querySelector(".team1").classList.remove("d-none")
-        document.querySelector(".team1").textContent = driver1Sel.children[0].children[1].innerText
-        document.querySelector(".team1").dataset.teamid = driver1Sel.dataset.teamid
+        const teamId = Number(driver1Sel.dataset.teamid)
+        document.querySelector(".team1").dataset.teamid = teamId
+        renderTeamLogo(document.querySelector(".team1"), teamId)
     }
 
 }
@@ -996,8 +1117,9 @@ function nameTitleD2(aDriver2) {
         document.querySelector(".driver2-first").classList.add("d-none")
         document.querySelector(".driver2-second").classList.add("d-none")
         document.querySelector(".team2").classList.remove("d-none")
-        document.querySelector(".team2").textContent = driver2Sel.children[0].children[1].innerText
-        document.querySelector(".team2").dataset.teamid = driver2Sel.dataset.teamid
+        const teamId = Number(driver2Sel.dataset.teamid)
+        document.querySelector(".team2").dataset.teamid = teamId
+        renderTeamLogo(document.querySelector(".team2"), teamId)
     }
 }
 
@@ -1472,6 +1594,20 @@ function findLastNonNaNIndex(arr) {
     return -1; // Devuelve -1 si todos los valores son NaN
 }
 
+function getLineChartAnimation() {
+    const delayBetweenPoints = 50;
+    return {
+        duration: 700,
+        easing: 'linear',
+        delay(context) {
+            if (context.type !== 'data') {
+                return 0;
+            }
+            return context.dataIndex * delayBetweenPoints;
+        }
+    };
+}
+
 function updateMaxYAxis(newMax) {
     driverGraph.options.scales.y.max = newMax;
     qualiGraph.options.scales.y.max = newMax;
@@ -1495,6 +1631,7 @@ function createRaceChart(labelsArray, max) {
             options: {
                 responsive: true,
                 maintainAspectRatio: false,
+                animation: getLineChartAnimation(),
                 interaction: {
                     mode: 'index'
                 },
@@ -1620,6 +1757,7 @@ function createQualiChart(labelsArray, max, q2_line) {
             options: {
                 responsive: true,
                 maintainAspectRatio: false,
+                animation: getLineChartAnimation(),
                 interaction: {
                     mode: 'index'
                 },
@@ -1751,6 +1889,7 @@ function createPointsChart(labelsArray) {
             options: {
                 responsive: true,
                 maintainAspectRatio: false,
+                animation: getLineChartAnimation(),
                 interaction: {
                     mode: 'index'
                 },

--- a/src/styles.css
+++ b/src/styles.css
@@ -11167,6 +11167,11 @@ input[type='number'] {
   transition: color 0.15s;
 }
 
+.team-h2h-logo {
+  width: 40px;
+  height: 40px;
+}
+
 
 #redbull,
 .rbborder-down:hover {


### PR DESCRIPTION
### Motivation
- Replace team name text in the head‑to‑head header cards with team logos to make team comparisons more visual and consistent with other UI lists.

### Description
- Import `logos_disc` in `src/js/frontend/head2head.js` and add a helper `renderTeamLogo(container, teamId)` to render an `<img>` logo with a text fallback and tooltip using `combined_dict`.
- Replace the team text updates in `nameTitleD1` and `nameTitleD2` to call `renderTeamLogo` and set the `.team1`/`.team2` `data-teamid` attributes.
- Add a small CSS rule `.team-h2h-logo` in `src/styles.css` to size the header logos consistently.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69859670be00833287f5e5391da851d7)