### PR TITLE
Use placeholder Honda logo path and keep engine logo visible when switching modes

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3649,7 +3649,7 @@
                       <a class="redesigned-dropdown-item" style="cursor: pointer;" data-engine="4">Red Bull
                         Powertrains</a>
                       <a class="redesigned-dropdown-item" style="cursor: pointer;" data-engine="7">Mercedes</a>
-                      <a class="redesigned-dropdown-item" style="cursor: pointer;" data-engine="10">Renault</a>
+                      <a class="redesigned-dropdown-item renault-engine-menu-item" style="cursor: pointer;" data-engine="10">Renault</a>
                     </ul>
                   </div>
                 </div>
@@ -5439,7 +5439,10 @@
 
         <div class="main-columns-drag-section main-resizable engines-show d-none" id="enginesPerformance">
           <div class="engine-performance" data-engineid="1">
-            <div class="engine-performance-title engine-fe">FERRARI</div>
+            <div class="engine-performance-title engine-fe">
+              <img class="engine-performance-logo" src="../assets/images/logos/ferrari.png" alt="Ferrari logo">
+              FERRARI
+            </div>
             <div class="engine-performance-stats">
               <div class="engine-performance-stat" data-attribute="10">
                 <div class="part-performance-stat-title">Power <span class="unit-measure bold-font">%</span></div>
@@ -5527,7 +5530,10 @@
             </div>
           </div>
           <div class="engine-performance" data-engineid="4">
-            <div class="engine-performance-title engine-rb">RED BULL POWERTRAINS</div>
+            <div class="engine-performance-title engine-rb">
+              <img class="engine-performance-logo" src="../assets/images/logos/redbull.png" alt="Red Bull logo">
+              RED BULL POWERTRAINS
+            </div>
             <div class="engine-performance-stats">
               <div class="engine-performance-stat" data-attribute="10">
                 <div class="part-performance-stat-title">Power <span class="unit-measure bold-font">%</span></div>
@@ -5615,7 +5621,10 @@
             </div>
           </div>
           <div class="engine-performance" data-engineid="7">
-            <div class="engine-performance-title engine-me">MERCEDES</div>
+            <div class="engine-performance-title engine-me">
+              <img class="engine-performance-logo" src="../assets/images/logos/mercedes.png" alt="Mercedes logo">
+              MERCEDES
+            </div>
             <div class="engine-performance-stats">
               <div class="engine-performance-stat" data-attribute="10">
                 <div class="part-performance-stat-title">Power <span class="unit-measure bold-font">%</span></div>
@@ -5703,7 +5712,10 @@
             </div>
           </div>
           <div class="engine-performance" data-engineid="10">
-            <div class="engine-performance-title engine-re">RENAULT</div>
+            <div class="engine-performance-title engine-re renault-engine-title">
+              <img class="engine-performance-logo renault-engine-logo" src="../assets/images/logos/renault.png" alt="Renault logo">
+              <span class="renault-engine-title-text">RENAULT</span>
+            </div>
             <div class="engine-performance-stats">
               <div class="engine-performance-stat" data-attribute="10">
                 <div class="part-performance-stat-title">Power <span class="unit-measure bold-font">%</span></div>

--- a/src/js/backend/scriptUtils/dbUtils.js
+++ b/src/js/backend/scriptUtils/dbUtils.js
@@ -3398,7 +3398,8 @@ export function fetchCustomConfig() {
     primaryColor: null,
     secondaryColor: null,
     turningPointsFrequencyPreset: defaultTurningPointsFrequencyPreset,
-    forceEditorMinimapColors: 0
+    forceEditorMinimapColors: 0,
+    renaultEngine: 'renault'
   };
 
   rows.forEach(row => {
@@ -3415,11 +3416,19 @@ export function fetchCustomConfig() {
       config.difficulty = value;
     } else if (key === 'turningPointsFrequencyPreset') {
       config.turningPointsFrequencyPreset = parseInt(value, 10);
-
+    } else if (key === 'Renault_engine') {
+      if (String(value).toLowerCase() === 'honda') {
+        config.renaultEngine = 'honda';
+      } else {
+        config.renaultEngine = 'renault';
+      }
     } else if (key === 'forceEditorMinimapColors') {
       config.forceEditorMinimapColors = parseInt(value, 10) === 1 ? 1 : 0;
     }
   });
+
+  const engine10Name = config.renaultEngine === 'honda' ? 'Honda' : 'Renault';
+  queryDB(`UPDATE Custom_Engines_List SET name = ? WHERE engineId = 10`, [engine10Name], 'run');
 
   const triggers = fetchExistingTriggers()
   const playerTeam = fetchPlayerTeam()

--- a/src/js/frontend/renderer.js
+++ b/src/js/frontend/renderer.js
@@ -1472,6 +1472,12 @@ function replace_all_teams(info) {
 }
 
 function manage_config_content(info, year_config = false) {
+    if (info["renaultEngine"] === "honda") {
+        setRenaultEnginePresentation("honda");
+    }
+    else {
+        setRenaultEnginePresentation("renault");
+    }
     replace_all_teams(info)
     if (!year_config) {
         let image = localStorage.getItem(`${saveName}_image`);
@@ -1517,6 +1523,47 @@ function manage_config_content(info, year_config = false) {
             turningPointsFrequencySlider.value = String(presetIndex);
             updateTurningPointsFrequencyUI();
         }
+    }
+}
+
+function setRenaultEnginePresentation(engineMode) {
+    const engineMenuItem = document.querySelector(".renault-engine-menu-item");
+    const engineTitleText = document.querySelector(".renault-engine-title-text");
+    const renaultLogo = document.querySelector(".renault-engine-logo");
+
+    if (engineMode === "honda") {
+        if (engineMenuItem) {
+            engineMenuItem.textContent = "Honda";
+        }
+        if (engineTitleText) {
+            engineTitleText.textContent = "HONDA";
+        }
+        if (renaultLogo) {
+            renaultLogo.src = "../assets/images/logos/honda.jpg";
+            renaultLogo.alt = "Honda logo";
+        }
+    }
+    else {
+        if (engineMenuItem) {
+            engineMenuItem.textContent = "Renault";
+        }
+        if (engineTitleText) {
+            engineTitleText.textContent = "RENAULT";
+        }
+        if (renaultLogo) {
+            renaultLogo.src = "../assets/images/logos/renault.png";
+            renaultLogo.alt = "Renault logo";
+        }
+    }
+
+    const renaultEngineTitle = document.querySelector(".renault-engine-title");
+    if (renaultEngineTitle) {
+        renaultEngineTitle.classList.remove("engine-re", "engine-ho");
+        renaultEngineTitle.classList.add(engineMode === "honda" ? "engine-ho" : "engine-re");
+    }
+
+    if (renaultLogo) {
+        renaultLogo.style.display = "inline-block";
     }
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -6104,6 +6104,10 @@ body.light-theme .flag-header img {
   border-bottom: 2px solid var(--renault-primary);
 }
 
+.engine-ho {
+  border-bottom: 2px solid var(--renault-primary);
+}
+
 .engine-me {
   border-bottom: 2px solid var(--mercedes-primary);
 }
@@ -6170,7 +6174,16 @@ input.engine-performance-title:focus {
 }
 
 .engine-performance-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   max-width: max-content;
+}
+
+.engine-performance-logo {
+  width: 20px;
+  height: 20px;
+  object-fit: contain;
 }
 
 .engine-modal-body {


### PR DESCRIPTION
### Motivation
- Allow the app to toggle the Renault/Honda presentation at runtime while keeping the engine logo visible so a later-added Honda asset will render without further code changes.
- Ensure the UI updates (menu text, title text, title class and logo) are targeted to specific elements so switching is reversible and safe.

### Description
- Backend: `fetchCustomConfig()` now initializes `renaultEngine` and reads `Renault_engine` from `Custom_Save_Config`, and updates `Custom_Engines_List` for `engineId = 10` to the runtime name (`Honda`/`Renault`).
- Frontend: `manage_config_content()` calls `setRenaultEnginePresentation()` and the new `setRenaultEnginePresentation(engineMode)` updates the engine dropdown item text, engine title text, toggles `engine-re`/`engine-ho` classes, and sets the logo `src`/`alt` to `../assets/images/logos/honda.jpg` in Honda mode (or `renault.png` in Renault mode) while keeping the logo visible (`inline-block`).
- Markup: added targeted markers and logo elements (e.g. `.renault-engine-menu-item`, `.renault-engine-title`, `.renault-engine-title-text`, `.renault-engine-logo`) in `src/index.html` so only intended UI nodes are affected by the toggle.
- Styling: added `.engine-ho` and `.engine-performance-logo` rules to `src/styles.css` to style the Honda state and ensure logos align/size correctly with titles.

### Testing
- Ran `npm run build` and webpack compiled successfully (with warnings) and the build completed.
- Served the `dist` directory with `python3 -m http.server 4173 --directory dist` and the static server responded as expected.
- Captured a Playwright (Firefox) screenshot of the running app to validate UI rendering and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c24115abc8332ab0941327d9357a1)