### PR TITLE
Add 2026 engine performance data and apply workflow (Audi engine, allocations, UI)

### DIFF
--- a/src/data/2026_changes.json
+++ b/src/data/2026_changes.json
@@ -369,7 +369,7 @@
             "SeasonID": 2025
         },
         {
-            "DriverID": 376, 
+            "DriverID": 376,
             "LastPointsChange": 0,
             "LastPositionChange": 0,
             "Points": 150,
@@ -378,7 +378,7 @@
             "SeasonID": 2025
         },
         {
-            "DriverID": 144, 
+            "DriverID": 144,
             "LastPointsChange": 0,
             "LastPositionChange": 0,
             "Points": 51,
@@ -387,7 +387,7 @@
             "SeasonID": 2025
         },
         {
-            "DriverID": 142, 
+            "DriverID": 142,
             "LastPointsChange": 0,
             "LastPositionChange": 0,
             "Points": 41,
@@ -396,7 +396,7 @@
             "SeasonID": 2025
         },
         {
-            "DriverID": 95, 
+            "DriverID": 95,
             "LastPointsChange": 0,
             "LastPositionChange": 0,
             "Points": 38,
@@ -405,7 +405,7 @@
             "SeasonID": 2025
         },
         {
-            "DriverID": 279, 
+            "DriverID": 279,
             "LastPointsChange": 0,
             "LastPositionChange": 0,
             "Points": 19,
@@ -431,5 +431,42 @@
             "RaceFormula": 1,
             "SeasonID": 2025
         }
-    ]
+    ],
+    "EnginePerformance": {
+        "mercedes": {
+            "10": 85,
+            "6": 80,
+            "14": 80,
+            "18": 73,
+            "19": 90
+        },
+        "ferrari": {
+            "10": 72,
+            "6": 95,
+            "14": 90,
+            "18": 95,
+            "19": 90
+        },
+        "rbpt": {
+            "10": 80,
+            "6": 73,
+            "14": 79,
+            "18": 85,
+            "19": 85
+        },
+        "audi": {
+            "10": 60,
+            "6": 75,
+            "14": 55,
+            "18": 70,
+            "19": 45
+        },
+        "honda": {
+            "10": 30,
+            "6": 70,
+            "14": 30,
+            "18": 30,
+            "19": 33
+        }
+    }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -6188,9 +6188,9 @@
                 <div class="one-change-description">Placeholder team order</div>
                 <div class="one-change-description">Placeholder car balance</div>
               </div>
-              <button class="one-change-button disabled">
+              <button class="one-change-button change-performance-2026">
                 <i class="bi bi-check-lg icon-hidden"></i>
-                <span>Coming soon</span>
+                <span>Apply</span>
               </button>
             </div>
           </div>

--- a/src/js/backend/scriptUtils/modUtils.js
+++ b/src/js/backend/scriptUtils/modUtils.js
@@ -8,8 +8,9 @@ import contracts from "../../../data/contracts_2025.json"
 import changes from "../../../data/2025_changes.json"
 import changes2026 from "../../../data/2026_changes.json"
 import tables2026 from "../../../data/tables_2026.json"
-import { fetchEngines, setCustomSaveConfig, updateCustomEngines, wipeTableAndRefill } from "./dbUtils.js";
+import { editEngines, fetchEngines, setCustomSaveConfig, updateCustomEngines, wipeTableAndRefill } from "./dbUtils.js";
 import { update } from "idb-keyval";
+import { manage_engine_change } from "./editTeamUtils.js";
 
 
 export function timeTravelWithData(dayNumber, extend = false, mod = "2025") {
@@ -1163,6 +1164,51 @@ export function addAudiCustomEngine(unitValue = 80) {
     updateSeasonModTable("change-regulations-2026", 1, "2026");
 
     return audiEngineId;
+}
+
+
+export function apply2026EnginePerformanceChanges() {
+    updateRenaultToHonda(true);
+
+    let audiEngineId = null;
+    try {
+        audiEngineId = addAudiCustomEngine(80);
+    }
+    catch (e) {
+        console.warn("Failed to add custom Audi engine:", e);
+    }
+
+    try {
+        manage_engine_change(10, 10);
+        if (audiEngineId != null) {
+            manage_engine_change(9, audiEngineId);
+        }
+        manage_engine_change(5, 7);
+    }
+    catch (e) {
+        console.warn("Failed to update engine allocations:", e);
+    }
+
+    const enginePerformance = changes2026?.EnginePerformance || {};
+    const engineStatsById = {
+        1: enginePerformance.ferrari,
+        4: enginePerformance.rbpt,
+        7: enginePerformance.mercedes,
+        10: enginePerformance.honda
+    };
+
+    if (audiEngineId != null) {
+        engineStatsById[audiEngineId] = enginePerformance.audi;
+    }
+
+    const enginesToEdit = Object.fromEntries(
+        Object.entries(engineStatsById).filter(([, stats]) => !!stats)
+    );
+
+    if (Object.keys(enginesToEdit).length > 0) {
+        editEngines(enginesToEdit);
+        updateSeasonModTable("change-performance-2026", 1, "2026");
+    }
 }
 
 export function insertStaff2026() {

--- a/src/js/backend/worker.js
+++ b/src/js/backend/worker.js
@@ -22,13 +22,14 @@ import { editAge, editMarketability, editName, editRetirement, editSuperlicense,
 import { editCalendar, fetchCalendar } from "./scriptUtils/calendarUtils";
 import { fireDriver, hireDriver, swapDrivers, editContract, futureContract, transferJuniorDriver, CONTRACT_PLACEHOLDERS_24 } from "./scriptUtils/transferUtils";
 import { change2024Standings, changeDriverLineUps, changeStats, removeFastestLap, timeTravelWithData, manageAffiliates, changeRaces, manageStandings, 
-  insertStaff2025, manageFeederSeries, changeDriverEngineerPairs, updatePerofmrnace2025, fixes_mod, addAudiCustomEngine, updateRenaultToHonda,
+  insertStaff2025, manageFeederSeries, changeDriverEngineerPairs, updatePerofmrnace2025, fixes_mod,
   change2025Standings, 
   updateCalendar2026,
   changeStats2026,
   insertStaff2026,
   changeLineUps2026,
-  changeDriverNumbers2026} from "./scriptUtils/modUtils";
+  changeDriverNumbers2026,
+  apply2026EnginePerformanceChanges} from "./scriptUtils/modUtils";
 import {
   generate_news, getOneQualiDetails, getOneRaceDetails, getTransferDetails, getTeamComparisonDetails,
   getFullChampionSeasonDetails, generateTurningResponse, upsertNews,
@@ -55,7 +56,6 @@ import { excelToDate } from "./scriptUtils/eidtStatsUtils";
 import { analyzeFileToDatabase, repack } from "./UESaveHandler";
 import { fetchRegulationsData, updateRegulations } from "./scriptUtils/regulationsUtils.js";
 import { deleteProblematicTriggers } from "./scriptUtils/triggerUtils.js";
-import { manage_engine_change } from "./scriptUtils/editTeamUtils.js";
 
 import initSqlJs from 'sql.js';
 import { combined_dict } from "../frontend/config";
@@ -904,26 +904,7 @@ const workerCommands = {
     postMessage({ responseMessage: "Points regulations fetched", content: pointsInfo });
   },
   add2026Engines: (data, postMessage) => {
-    updateRenaultToHonda(true);
-
-    let audiEngineId = null;
-    try {
-      audiEngineId = addAudiCustomEngine(80);
-    }
-    catch (e) {
-      console.warn("Failed to add custom Audi engine:", e);
-    }
-
-    try {
-      manage_engine_change(10, 10);
-      if (audiEngineId != null) {
-        manage_engine_change(9, audiEngineId);
-      }
-      manage_engine_change(5, 7);
-    }
-    catch (e) {
-      console.warn("Failed to update engine allocations:", e);
-    }
+    apply2026EnginePerformanceChanges();
 
     const engines = fetchEngines();
     postMessage({ responseMessage: "Engines fetched", content: engines });

--- a/src/js/frontend/seasonMods.js
+++ b/src/js/frontend/seasonMods.js
@@ -408,9 +408,6 @@ function initMods2026Actions(){
       const command = new Command("changeRegulations", {mod: "2026"});
       try {
         command.execute();
-        const command2 = new Command("add2026Engines", {mod: "2026"});
-        command2.execute();
-        setRenaultEnginePresentation("honda");
 
         this.classList.add("completed");
         this.querySelector("span").textContent = "Applied";
@@ -420,6 +417,18 @@ function initMods2026Actions(){
         this.dataset.running = "0";
         this.classList.remove("disabled");
       }
+    });
+  }
+
+  const changePerformanceButton2026 = mods2026View.querySelector(".change-performance-2026");
+  if (changePerformanceButton2026) {
+    changePerformanceButton2026.addEventListener("click", function () {
+      const command = new Command("add2026Engines", {mod: "2026"});
+      command.execute();
+      setRenaultEnginePresentation("honda");
+      this.classList.add("completed");
+      this.querySelector("span").textContent = "Applied";
+      syncMods2026ApplyAllButtonState();
     });
   }
 


### PR DESCRIPTION
### Motivation

- Implement engine performance adjustments for the 2026 mod including adding a custom Audi engine and reassigning engine allocations so the mod can alter car performance per engine supplier.
- Surface a dedicated UI control to apply performance changes separately from regulation changes.

### Description

- Added `EnginePerformance` data to `src/data/2026_changes.json` containing per-engine performance stats for `mercedes`, `ferrari`, `rbpt`, `audi`, and `honda`.
- Implemented `apply2026EnginePerformanceChanges` in `src/js/backend/scriptUtils/modUtils.js`, which adds a custom Audi engine via `addAudiCustomEngine`, updates allocations with `manage_engine_change`, maps the `EnginePerformance` entries to engine IDs, and calls `editEngines` to apply stats and `updateSeasonModTable` to mark the mod applied.
- Updated the worker command `add2026Engines` in `src/js/backend/worker.js` to call the new `apply2026EnginePerformanceChanges` helper instead of inlining the logic, and adjusted imports accordingly.
- Enabled the front-end control by changing the button in `src/index.html` and wiring the new `change-performance-2026` button in `src/js/frontend/seasonMods.js` to execute the `add2026Engines` command and update the UI state.

### Testing

- Performed a development build (`npm run build`) which completed successfully.
- Executed the worker `add2026Engines` path in a local dev run and confirmed the new `apply2026EnginePerformanceChanges` function runs without uncaught exceptions and returns engine data via the worker response.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a02411b8948332bbf787b3ad139528)