### PR TITLE
Add Overview mode to Performance view toggle

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -5805,6 +5805,7 @@
                   <div class="engine-performance-progress"></div>
                 </div>
               </div>
+              <div class="performance-show overview-show d-none" id="performanceOverview"></div>
             </div>
           </div>
         </div>

--- a/src/js/frontend/performance.js
+++ b/src/js/frontend/performance.js
@@ -25,6 +25,20 @@ export let viewingGraph = true;
 let actualMaxDesign = 0;
 let customEnginesCopy;
 let currentData;
+let performanceView = "graph";
+
+const overviewAttributes = [
+    { key: "engine_power", label: "Engine Power", source: "overall" },
+    { key: "top_speed", label: "Top speed" },
+    { key: "acceleration", label: "Acceleration" },
+    { key: "low_speed", label: "Low speed" },
+    { key: "medium_speed", label: "Medium speed" },
+    { key: "high_speed", label: "High speed" },
+    { key: "drs", label: "DRS Effectiveness" },
+    { key: "dirty_air", label: "Dirty air tolerance" },
+    { key: "brake_cooling", label: "Brake cooling" },
+    { key: "engine_cooling", label: "Engine cooling" }
+];
 
 function normalizeData(data) {
     let values = Object.values(data);
@@ -113,6 +127,7 @@ export function load_attributes(teams) {
             bar.dataset[attribute] = attributeValue.toFixed(3);
         }
     }
+    load_overview();
 }
 
 export function load_car_attributes(teams) {
@@ -207,12 +222,12 @@ teamsPill.addEventListener("click", function () {
     document.querySelector("#carAttributeSelector").classList.remove("d-none")
     document.querySelector("#customEnginesButtonContainer").classList.add("d-none")
     removeSelected()
-    if (viewingGraph) {
-        document.querySelector(".save-button").classList.add("d-none")
-    }
-    else {
+    if (performanceView === "details") {
         document.querySelector(".save-button").classList.remove("d-none")
         first_show_animation()
+    }
+    else {
+        document.querySelector(".save-button").classList.add("d-none")
     }
 })
 
@@ -294,18 +309,11 @@ document.querySelectorAll(".team").forEach(function (elem) {
     elem.addEventListener("click", function () {
         removeSelected()
         manageSaveButton(true, "performance")
-        performanceGraphButton.classList.remove("active")
-        performanceGraphIcon.className = "bi bi-list-ul"
-        performanceGraphText.textContent = "Details"
+        setPerformanceView("details")
         elem.classList.toggle('selected');
         teamSelected = elem.dataset.teamid;
         const command = new Command("performanceRequest",  { teamID: teamSelected});
         command.execute();
-        document.querySelector("#performanceGraph").classList.add("d-none")
-        document.querySelector(".teams-show").classList.remove("d-none")
-        document.querySelector(".save-button").classList.remove("d-none")
-        first_show_animation()
-        viewingGraph = false;
     })
 })
 
@@ -313,18 +321,11 @@ document.querySelectorAll(".car").forEach(function (elem) {
     elem.addEventListener("click", function () {
         removeSelected()
         manageSaveButton(true, "performance")
-        performanceGraphButton.classList.remove("active")
-        performanceGraphIcon.className = "bi bi-list-ul"
-        performanceGraphText.textContent = "Details"
+        setPerformanceView("details")
         elem.classList.toggle('selected');
         teamSelected = elem.dataset.teamid;
         const command = new Command("performanceRequest",  { teamID: teamSelected});
         command.execute();
-        document.querySelector("#performanceGraph").classList.add("d-none")
-        document.querySelector(".teams-show").classList.remove("d-none")
-        document.querySelector(".save-button").classList.remove("d-none")
-        first_show_animation()
-        viewingGraph = false;
     })
 })
 
@@ -746,22 +747,125 @@ document.querySelector(".performance-show").querySelectorAll(".new-or-existing-p
 const performanceGraphButton = document.getElementById("performanceGraphButton");
 const performanceGraphIcon = performanceGraphButton.querySelector("i");
 const performanceGraphText = performanceGraphButton.querySelector("span");
+const performanceOverview = document.getElementById("performanceOverview");
+
+function setPerformanceView(view) {
+    performanceView = view;
+    viewingGraph = view === "graph";
+
+    performanceGraphButton.classList.add("active");
+    if (view === "graph") {
+        performanceGraphIcon.className = "bi bi-graph-up";
+        performanceGraphText.textContent = "Graph";
+    }
+    else if (view === "details") {
+        performanceGraphIcon.className = "bi bi-list-ul";
+        performanceGraphText.textContent = "Details";
+    }
+    else {
+        performanceGraphIcon.className = "bi bi-grid-3x2-gap";
+        performanceGraphText.textContent = "Overview";
+    }
+
+    document.querySelector("#performanceGraph").classList.toggle("d-none", view !== "graph");
+    document.querySelector(".teams-show").classList.toggle("d-none", view !== "details");
+    performanceOverview.classList.toggle("d-none", view !== "overview");
+
+    document.querySelector(".save-button").classList.toggle("d-none", view !== "details");
+
+    if (view === "details") {
+        first_show_animation();
+    }
+    if (view === "overview") {
+        load_overview();
+    }
+}
+
+function createOverviewCard(attributeConfig) {
+    let card = document.createElement("div");
+    card.classList.add("overview-card");
+
+    let title = document.createElement("div");
+    title.classList.add("overview-card-title", "bold-font");
+    title.textContent = attributeConfig.label;
+    card.appendChild(title);
+
+    let teamsContainer = document.createElement("div");
+    teamsContainer.classList.add("overview-card-teams");
+
+    document.querySelectorAll("#teamsDiv .team-performance").forEach(function (teamElem) {
+        let teamId = teamElem.dataset.teamid;
+        let sourceBar = teamElem.querySelector(".performance-bar-progress");
+        if (!sourceBar) {
+            return;
+        }
+
+        let teamRow = document.createElement("div");
+        teamRow.classList.add("overview-team", "bold-font");
+        if (teamElem.classList.contains("d-none")) {
+            teamRow.classList.add("d-none");
+        }
+
+        let carTitle = document.createElement("div");
+        carTitle.classList.add("car-title");
+
+        let teamName = document.createElement("span");
+        teamName.className = teamElem.querySelector(".team-title-name").className;
+        teamName.textContent = teamElem.querySelector(".team-title-name").textContent;
+        carTitle.appendChild(teamName);
+
+        let teamValue = document.createElement("span");
+        teamValue.classList.add("overview-team-value");
+        carTitle.appendChild(teamValue);
+
+        let performanceBar = document.createElement("div");
+        performanceBar.classList.add("performance-bar");
+        let progressBar = document.createElement("div");
+        progressBar.className = sourceBar.className;
+        performanceBar.appendChild(progressBar);
+
+        teamRow.appendChild(carTitle);
+        teamRow.appendChild(performanceBar);
+
+        let sourceKey = attributeConfig.source || attributeConfig.key;
+        let value = parseFloat(sourceBar.dataset[sourceKey] || 0);
+        progressBar.style.width = value + "%";
+        teamValue.textContent = value.toFixed(2) + " %";
+
+        teamRow.dataset.teamid = teamId;
+        teamRow.dataset.attribute = attributeConfig.key;
+
+        teamsContainer.appendChild(teamRow);
+    });
+
+    card.appendChild(teamsContainer);
+    return card;
+}
+
+function load_overview() {
+    if (!performanceOverview) {
+        return;
+    }
+    performanceOverview.innerHTML = "";
+    overviewAttributes.forEach(function (attributeConfig) {
+        performanceOverview.appendChild(createOverviewCard(attributeConfig));
+    });
+}
 
 document.querySelector("#performanceGraphButton").addEventListener("click", function () {
-    if (!viewingGraph) {
-        performanceGraphButton.classList.add("active")
-        performanceGraphIcon.className = "bi bi-graph-up"
-        performanceGraphText.textContent = "Graph"
-        document.querySelector(".teams-show").classList.add("d-none")
-        document.querySelector("#performanceGraph").classList.remove("d-none")
+    if (performanceView === "graph") {
+        setPerformanceView("details");
     }
-    removeSelected()
-    document.querySelector(".save-button").classList.add("d-none")
-    viewingGraph = true;
+    else if (performanceView === "details") {
+        setPerformanceView("overview");
+    }
+    else {
+        removeSelected();
+        setPerformanceView("graph");
+    }
 })
 
-performanceGraphIcon.className = "bi bi-graph-up"
-performanceGraphText.textContent = "Graph"
+setPerformanceView("graph");
 
 document.querySelectorAll(".part-performance-title .bi-chevron-up").forEach(function (elem) {
     elem.addEventListener("click", function () {

--- a/src/styles.css
+++ b/src/styles.css
@@ -6682,6 +6682,61 @@ input.engine-performance-title:focus {
 }
 
 
+
+.overview-show {
+  background-color: transparent !important;
+  box-shadow: none !important;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-rows: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  flex: 1;
+  padding-right: 7px;
+  overflow-y: auto;
+}
+
+.overview-card {
+  background-color: var(--component-general);
+  border: 1px solid var(--separator);
+  border-radius: 10px;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.overview-card-title {
+  font-size: 13px;
+  color: var(--text-general);
+  margin-bottom: 6px;
+}
+
+.overview-card-teams {
+  display: grid;
+  gap: 2px;
+  overflow-y: auto;
+  min-height: 0;
+}
+
+.overview-team .car-title {
+  font-size: 10px;
+  height: auto;
+  padding-bottom: 0;
+}
+
+.overview-team .performance-bar {
+  height: 3px;
+  margin: 1px 0 2px;
+}
+
+.overview-team .performance-bar-progress {
+  height: 3px;
+}
+
+.overview-team-value {
+  color: var(--dark-text);
+  font-size: 10px;
+}
 .teams-show,
 .engines-show {
   background-color: transparent !important;
@@ -6693,7 +6748,8 @@ input.engine-performance-title:focus {
   flex: 1;
 }
 
-.main-columns-drag-section:has(.teams-show:not(.d-none)){
+.main-columns-drag-section:has(.teams-show:not(.d-none)),
+.main-columns-drag-section:has(.overview-show:not(.d-none)){
   background-color: transparent !important;
   box-shadow: none !important;
 }


### PR DESCRIPTION
### Motivation
- Provide a compact Overview mode in the Performance panel that shows multiple attributes at-a-glance in a 2×5 grid of mini team charts, reusing the compact car-performance bar layout and keeping team-name markers compatible with existing replacement logic.

### Description
- Added an Overview container to `src/index.html` and overview-specific styling to `src/styles.css` to render a 2-row × 5-column grid of attribute cards.
- Added `performanceView` state and `overviewAttributes` mapping and implemented `setPerformanceView` in `src/js/frontend/performance.js` to cycle the view between Graph → Details → Overview and toggle visibility/icons/text accordingly.
- Implemented `createOverviewCard` and `load_overview` to generate per-attribute cards that reuse `.performance-bar` / `.performance-bar-progress` and the same team-title class names so team replacements still work, and hooked `load_attributes` to refresh the overview when data updates.
- Kept the implementation compact and readable, following the existing coding style and minimizing new DOM structure complexity.

### Testing
- Ran `npm run build` (webpack) and the build completed successfully (warnings only).  
- Served the app with `python3 -m http.server` and executed a headless Playwright navigation that exercised the Performance view and captured a screenshot demonstrating the Overview rendering (artifact captured).  
- Smoke validation completed: build and automated navigation finished without runtime failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a17b4a7fb083328552eff8a07d2be8)