### PR TITLE
Add engine condition save command

### DIFF
--- a/src/js/backend/scriptUtils/carAnalysisUtils.js
+++ b/src/js/backend/scriptUtils/carAnalysisUtils.js
@@ -1235,6 +1235,16 @@ export function setMinPowerUnitCondition(minCondition = 0.75) {
     return itemsToRepair;
 }
 
+export function updateTeamPowerUnitCondition(items) {
+    for (const item of items) {
+        queryDB(`
+            UPDATE Parts_Items
+            SET Condition = ?
+            WHERE ItemID = ?
+        `, [item.condition, item.itemID], "run");
+    }
+}
+
 const powerUnitSlots = [
     { key: "engine", partType: 0 },
     { key: "ers", partType: 1 },
@@ -2007,6 +2017,5 @@ export function deleteCustomEngineAndReassign(engineIdRaw, fallbackEngineIdRaw) 
 
     return { ok: true, fallbackEngineId, reassignedTeams: teamsSupplied.length };
 }
-
 
 

--- a/src/js/backend/worker.js
+++ b/src/js/backend/worker.js
@@ -23,7 +23,7 @@ import { getPerformanceAllTeamsSeason, getAttributesAllTeams, getPerformanceAllC
 import { setDatabase, getMetadata, getDatabase } from "./dbManager";
 import { fetchHead2Head, fetchHead2HeadTeam } from "./scriptUtils/head2head";
 import { editTeam, fetchTeamData } from "./scriptUtils/editTeamUtils";
-import { overwritePerformanceTeam, updateItemsForDesignDict, fitLoadoutsDict, getPartsFromTeam, getUnitValueFromParts, getAllPartsFromTeam, getMaxDesign, getUnitValueFromOnePart, deleteCustomEngineAndReassign, getTeamExpertise, getTeamNextSeasonCarExpertise, updateTeamExpertise, updateTeamNextSeasonExpertise, getTeamPowerUnitConditionData } from "./scriptUtils/carAnalysisUtils";
+import { overwritePerformanceTeam, updateItemsForDesignDict, fitLoadoutsDict, getPartsFromTeam, getUnitValueFromParts, getAllPartsFromTeam, getMaxDesign, getUnitValueFromOnePart, deleteCustomEngineAndReassign, getTeamExpertise, getTeamNextSeasonCarExpertise, updateTeamExpertise, updateTeamNextSeasonExpertise, getTeamPowerUnitConditionData, updateTeamPowerUnitCondition } from "./scriptUtils/carAnalysisUtils";
 import { setGlobals, getGlobals } from "./commandGlobals";
 import { editAge, editGeneratedStaffBasicData, editMarketability, editName, editRetirement, editSuperlicense, editCode, editMentality, editStats, setAllDriversStatsTo85 } from "./scriptUtils/eidtStatsUtils";
 import { editCalendar, fetchCalendar } from "./scriptUtils/calendarUtils";
@@ -598,6 +598,18 @@ const workerCommands = {
     postMessage(designResponse);
   },
   engineConditionRequest: (data, postMessage) => {
+    const engineConditions = getTeamPowerUnitConditionData(data.teamID);
+    postMessage({ responseMessage: "Engine conditions fetched", content: engineConditions });
+  },
+  editEngineCondition: (data, postMessage) => {
+    updateTeamPowerUnitCondition(data.items);
+    postMessage({
+      responseMessage: "Engine conditions updated",
+      noti_msg: `Succesfully edited ${teamReplaceDict[data.teamName]}'s engine part condition`,
+      isEditCommand: true,
+      unlocksDownload: true
+    });
+
     const engineConditions = getTeamPowerUnitConditionData(data.teamID);
     postMessage({ responseMessage: "Engine conditions fetched", content: engineConditions });
   },

--- a/src/js/frontend/performance.js
+++ b/src/js/frontend/performance.js
@@ -782,6 +782,20 @@ export function load_engine_conditions(data) {
     });
 }
 
+export function gather_engine_condition_data() {
+    const items = [];
+
+    document.querySelectorAll(".engine-condition-part .engine-performance-stat").forEach(function (stat) {
+        const input = stat.querySelector(".custom-input-number");
+        items.push({
+            itemID: Number(stat.dataset.itemid),
+            condition: Number(input.value) / 100
+        });
+    });
+
+    return items;
+}
+
 export function gather_team_expertise_data() {
     let expertise = {};
     document.querySelectorAll(".part-performance").forEach(function (elem) {
@@ -2024,7 +2038,6 @@ function createPerformanceChart(labelsArray) {
         }
     );
 }
-
 
 
 

--- a/src/js/frontend/renderer.js
+++ b/src/js/frontend/renderer.js
@@ -19,7 +19,7 @@ import { load_calendar } from './calendar';
   import {
       load_performance, load_performance_graph, load_attributes, manage_engineStats, load_cars, load_custom_engines,
       order_by, load_car_attributes, viewingGraph, load_parts_stats, load_parts_list, update_max_design, teamsEngine, load_one_part,
-      teamSelected, gather_engines_data, gather_custom_engines_data, reload_performance_graph, load_team_expertise, load_team_next_season_car, gather_team_expertise_data, performanceDetailsMode, setPerformanceCurrentSeason, load_engine_conditions,
+      teamSelected, gather_engines_data, gather_custom_engines_data, reload_performance_graph, load_team_expertise, load_team_next_season_car, gather_team_expertise_data, performanceDetailsMode, setPerformanceCurrentSeason, load_engine_conditions, gather_engine_condition_data,
       updateEngineLabels
   } from './performance';
 import {
@@ -714,6 +714,17 @@ function performanceModeHandler() {
         command.execute();
     }
     else if (teamsEngine === "engines") {
+        if (document.getElementById("teamEngineConditionEditor") && !document.getElementById("teamEngineConditionEditor").classList.contains("d-none")) {
+            data = {
+                teamID: teamSelected,
+                items: gather_engine_condition_data(),
+                teamName: document.querySelector(".selected").dataset.teamname
+            }
+            const command = new Command("editEngineCondition", data);
+            command.execute();
+            return;
+        }
+
         const engineData = gather_engines_data()
         const officialEngines = {}
         for (let engineId in engineData) {


### PR DESCRIPTION
### Motivation
- Provide a concrete save path for edits made in the engine-condition editor so frontend changes persist to the database. 
- Ensure the UI Save Changes button for engine-condition editing sends the correct payload to the backend and updates the editor with fresh data.

### Description
- Added `updateTeamPowerUnitCondition(items)` in `src/js/backend/scriptUtils/carAnalysisUtils.js` which updates `Parts_Items.Condition` for each submitted `ItemID`.
- Added a new worker command `editEngineCondition` in `src/js/backend/worker.js` that calls `updateTeamPowerUnitCondition`, posts a success notification, and re-fetches the engine-condition payload for the team.
- Added `gather_engine_condition_data()` in `src/js/frontend/performance.js` which collects each engine item `data-itemid` and the edited percentage input and converts it to a backend-friendly `condition` (0..1) value.
- Wired the save flow in `src/js/frontend/renderer.js` to send `editEngineCondition` when the engine-condition editor is visible, while preserving the existing engine-manufacturer save path when it is not.

### Testing
- Ran `npm run build` and the project compiled successfully with warnings (webpack reported 2 warnings), indicating the frontend/back-end bundles built.
- Verified the UI save-handler now sends an `editEngineCondition` command payload containing `teamID`, `teamName`, and `items` when the engine-condition editor is active.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1284a27b083328e7d8db7b7288dfe)