### PR TITLE
Add team overall adjustment feature (backend scaling + frontend controls)

### DIFF
--- a/src/js/backend/scriptUtils/carAnalysisUtils.js
+++ b/src/js/backend/scriptUtils/carAnalysisUtils.js
@@ -614,6 +614,148 @@ export function updateTeamNextSeasonExpertise(teamId, nextSeasonCarUnitValues, y
     }
 }
 
+function getOverallByMode(teamId, mode, customTeam = false, yearIteration = null) {
+    if (mode === "performance") {
+        const performance = getPerformanceAllTeams(null, null, customTeam);
+        return Number(performance[teamId] || 0);
+    }
+
+    if (mode === "nextSeasonCar") {
+        const attributes = getAttributesAllTeamsNextSeasonCar(customTeam, yearIteration);
+        return Number(attributes?.[teamId]?.overall || 0);
+    }
+
+    const attributes = getAttributesAllTeamsExpertise(customTeam, yearIteration);
+    return Number(attributes?.[teamId]?.overall || 0);
+}
+
+function cloneStatsDict(statsDict) {
+    return JSON.parse(JSON.stringify(statsDict || {}));
+}
+
+function scaleStatsDictUnitValues(statsDict, factor, yearIteration = null) {
+    const scaled = cloneStatsDict(statsDict);
+
+    for (const partKey of Object.keys(scaled)) {
+        if (partKey === "engine") continue;
+        const partStats = scaled[partKey] || {};
+
+        for (const statKey of Object.keys(partStats)) {
+            const stat = Number(statKey);
+            if (stat === 15 || stat === 10) continue;
+
+            const oldUnitValue = Number(partStats[statKey]);
+            let oldValue = oldUnitValue;
+            if (yearIteration === "24" && stat >= 7 && stat <= 9) {
+                oldValue = carConstants.downforce24UnitValueToValue[stat](oldUnitValue);
+            }
+            else if (carConstants.unitValueToValue?.[stat]) {
+                oldValue = carConstants.unitValueToValue[stat](oldUnitValue);
+            }
+
+            const newValue = oldValue * factor;
+
+            let nextUnitValue = newValue;
+            if (yearIteration === "24" && stat >= 7 && stat <= 9) {
+                nextUnitValue = carConstants.downforce24ValueToUnitValue[stat](newValue);
+            }
+            else if (carConstants.valueToUnitValue?.[stat]) {
+                nextUnitValue = carConstants.valueToUnitValue[stat](newValue);
+            }
+
+            const minMax = carConstants.statsMinMax[stat];
+            if (minMax) {
+                if (nextUnitValue < minMax[0]) nextUnitValue = minMax[0];
+                if (nextUnitValue > minMax[1]) nextUnitValue = minMax[1];
+            }
+
+            partStats[statKey] = Math.round(nextUnitValue * 1000) / 1000;
+        }
+    }
+
+    return scaled;
+}
+
+function buildPartTypeStats(statsDict) {
+    const mapped = {};
+    for (let partType = 3; partType < 9; partType++) {
+        const partName = carConstants.parts[partType];
+        mapped[partType] = cloneStatsDict(statsDict?.[partName] || {});
+    }
+    return mapped;
+}
+
+function buildPerformancePayload(teamId, statsDict) {
+    const designs = getPartsFromTeam(teamId);
+    const performancePayload = {};
+
+    for (let partType = 3; partType < 9; partType++) {
+        const partName = carConstants.parts[partType];
+        performancePayload[partName] = cloneStatsDict(statsDict?.[partName] || {});
+        performancePayload[partName].designEditing = designs?.[partType]?.[0]?.[0];
+    }
+
+    return performancePayload;
+}
+
+export function adjustTeamOverallToTarget(teamId, targetOverall, mode = "performance", customTeam = false, yearIteration = null) {
+    let target = Number(targetOverall);
+    if (target < 0) target = 0;
+    if (target > 100) target = 100;
+
+    let stats;
+    if (mode === "performance") {
+        stats = getUnitValueFromParts(getPartsFromTeam(teamId));
+    }
+    else if (mode === "nextSeasonCar") {
+        stats = getTeamNextSeasonCarExpertise(teamId, yearIteration);
+    }
+    else {
+        stats = getTeamExpertise(teamId, yearIteration);
+    }
+
+    let achieved = getOverallByMode(teamId, mode, customTeam, yearIteration);
+    let iterations = 0;
+
+    while (iterations < 8) {
+        if (Math.abs(target - achieved) <= 0.1) break;
+        if (!achieved) break;
+
+        const factor = target / achieved;
+        const scaled = scaleStatsDictUnitValues(stats, factor, yearIteration);
+
+        if (mode === "performance") {
+            const payload = buildPerformancePayload(teamId, scaled);
+            overwritePerformanceTeam(teamId, payload, customTeam, yearIteration);
+        }
+        else if (mode === "nextSeasonCar") {
+            updateTeamNextSeasonExpertise(teamId, buildPartTypeStats(scaled), yearIteration);
+        }
+        else {
+            updateTeamExpertise(teamId, buildPartTypeStats(scaled), yearIteration);
+        }
+
+        if (mode === "performance") {
+            stats = getUnitValueFromParts(getPartsFromTeam(teamId));
+        }
+        else if (mode === "nextSeasonCar") {
+            stats = getTeamNextSeasonCarExpertise(teamId, yearIteration);
+        }
+        else {
+            stats = getTeamExpertise(teamId, yearIteration);
+        }
+
+        achieved = getOverallByMode(teamId, mode, customTeam, yearIteration);
+        iterations += 1;
+    }
+
+    return {
+        requested: target,
+        achieved: Math.round(achieved * 100) / 100,
+        mode
+    };
+}
+
 export function getUnitValueFromOnePart(designId) {
 
     const partType = queryDB(`
@@ -2017,5 +2159,4 @@ export function deleteCustomEngineAndReassign(engineIdRaw, fallbackEngineIdRaw) 
 
     return { ok: true, fallbackEngineId, reassignedTeams: teamsSupplied.length };
 }
-
 

--- a/src/js/backend/worker.js
+++ b/src/js/backend/worker.js
@@ -23,7 +23,7 @@ import { getPerformanceAllTeamsSeason, getAttributesAllTeams, getPerformanceAllC
 import { setDatabase, getMetadata, getDatabase } from "./dbManager";
 import { fetchHead2Head, fetchHead2HeadTeam } from "./scriptUtils/head2head";
 import { editTeam, fetchTeamData } from "./scriptUtils/editTeamUtils";
-import { overwritePerformanceTeam, updateItemsForDesignDict, fitLoadoutsDict, getPartsFromTeam, getUnitValueFromParts, getAllPartsFromTeam, getMaxDesign, getUnitValueFromOnePart, deleteCustomEngineAndReassign, getTeamExpertise, getTeamNextSeasonCarExpertise, updateTeamExpertise, updateTeamNextSeasonExpertise, getTeamPowerUnitConditionData, updateTeamPowerUnitCondition } from "./scriptUtils/carAnalysisUtils";
+import { overwritePerformanceTeam, updateItemsForDesignDict, fitLoadoutsDict, getPartsFromTeam, getUnitValueFromParts, getAllPartsFromTeam, getMaxDesign, getUnitValueFromOnePart, deleteCustomEngineAndReassign, getTeamExpertise, getTeamNextSeasonCarExpertise, updateTeamExpertise, updateTeamNextSeasonExpertise, getTeamPowerUnitConditionData, updateTeamPowerUnitCondition, adjustTeamOverallToTarget } from "./scriptUtils/carAnalysisUtils";
 import { setGlobals, getGlobals } from "./commandGlobals";
 import { editAge, editGeneratedStaffBasicData, editMarketability, editName, editRetirement, editSuperlicense, editCode, editMentality, editStats, setAllDriversStatsTo85 } from "./scriptUtils/eidtStatsUtils";
 import { editCalendar, fetchCalendar } from "./scriptUtils/calendarUtils";
@@ -859,6 +859,39 @@ const workerCommands = {
       unlocksDownload: true
     };
     postMessage(carPerformanceResponse);
+  },
+  editTargetOverall: (data, postMessage) => {
+    let globals = getGlobals();
+    const yearData = checkYearSave();
+    const mode = data.mode || "performance";
+    const result = adjustTeamOverallToTarget(
+      data.teamID,
+      data.targetOverall,
+      mode,
+      globals.isCreateATeam,
+      globals.yearIteration
+    );
+
+    const [performance, races] = getPerformanceAllTeamsSeason(yearData[2], { useHistoricalEnginePower: true });
+    const aduoEngineUpgradeRaceIds = getAduoEngineUpgradeRaceIds();
+    postMessage({ responseMessage: "Season performance fetched", content: [performance, races, aduoEngineUpgradeRaceIds] });
+
+    const attributes = getAttributesAllTeams(yearData[2]);
+    const expertiseAttributes = getAttributesAllTeamsExpertise(yearData[2], globals.yearIteration);
+    const nextSeasonCarAttributes = getAttributesAllTeamsNextSeasonCar(yearData[2], globals.yearIteration);
+    postMessage({ responseMessage: "Performance fetched", content: [performance[performance.length - 1], attributes, expertiseAttributes, nextSeasonCarAttributes] });
+
+    const carPerformance = getPerformanceAllCars(yearData[2]);
+    const carAttributes = getAttributesAllCars(yearData[2]);
+    const carExpertiseAttributes = getAttributesAllCarsExpertise(yearData[2], globals.yearIteration);
+    const carNextSeasonAttributes = getAttributesAllCarsNextSeasonCar(yearData[2], globals.yearIteration);
+    postMessage({
+      responseMessage: "Cars fetched",
+      content: [carPerformance, carAttributes, carExpertiseAttributes, carNextSeasonAttributes],
+      noti_msg: `Adjusted ${teamReplaceDict[data.teamName]}'s ${mode} overall to ${result.achieved.toFixed(2)}%`,
+      isEditCommand: true,
+      unlocksDownload: true
+    });
   },
   editEngine: (data, postMessage) => {
     snapshotEnginePowerProgression(Object.keys(data?.engines || {}), 'pre_engine_edit');

--- a/src/js/frontend/performance.js
+++ b/src/js/frontend/performance.js
@@ -41,6 +41,7 @@ let nextSeasonCarDraftStats = null;
 let performanceAnnotationsToggle = true;
 let currentPerformanceCriterion = "overall";
 let performanceCurrentSeason = null;
+const overallAdjustStep = 0.5;
 
 const performanceDetailsModes = ["performance", "expertise", "nextSeasonCar"];
 const engineConditionSlots = [
@@ -94,6 +95,16 @@ function getDatasetKey(mode, criterion) {
 function setBarDatasetValue(bar, mode, criterion, value) {
     if (!bar) return;
     bar.dataset[getDatasetKey(mode, criterion)] = Number(value).toFixed(3);
+}
+
+function setTeamBarValue(teamElem, mode, value) {
+    const bar = teamElem?.querySelector(".performance-bar-progress");
+    const teamValue = teamElem?.querySelector(".team-title-value");
+    if (!bar || !teamValue) return;
+    setBarDatasetValue(bar, mode, "overall", value);
+    setBarWidth(bar, value);
+    teamValue.innerText = Number(value).toFixed(2) + " %";
+    updateBarModeClass(bar);
 }
 
 function getBarDatasetValue(bar, criterion) {
@@ -314,6 +325,17 @@ export function load_performance(teams) {
                     setBarWidth(performanceBarProgress, teams[key]);
                     team_value.innerText = teams[key].toFixed(2) + ' %';
                     updateBarModeClass(performanceBarProgress);
+                    let targetValue = teams[key];
+                    if (performanceDetailsMode === "expertise") {
+                        targetValue = getBarDatasetValue(performanceBarProgress, "overall");
+                    }
+                    if (performanceDetailsMode === "nextSeasonCar") {
+                        targetValue = getBarDatasetValue(performanceBarProgress, "overall");
+                    }
+                    const targetInput = teamPerformance.querySelector(".team-overall-adjust-input");
+                    if (targetInput) {
+                        targetInput.value = Number(targetValue).toFixed(2);
+                    }
                 }
             }
         }
@@ -371,6 +393,9 @@ export function load_attributes(teams, mode = "performance") {
             let attributeValue = teams[key][attribute];
             setBarDatasetValue(bar, mode, attribute, attributeValue);
         }
+    }
+    if (mode === performanceDetailsMode) {
+        syncOverviewAdjustControlsWithMode();
     }
     load_overview();
 }
@@ -454,6 +479,7 @@ teamsCarsButton.addEventListener("click", function () {
 })
 
 updateTeamsCarsButton();
+setupOverviewAdjustControls();
 
 
 document.querySelector("#attributeMenu").querySelectorAll("a").forEach(function (elem) {
@@ -1300,6 +1326,9 @@ function setPerformanceSubview(section, subview) {
         performanceAnnotationsToggleWrapper.classList.toggle("d-none", !isGraphView);
     }
     document.querySelector(".save-button").classList.toggle("d-none", isTeamsSection && performanceView !== "details");
+    document.querySelectorAll(".team-overall-adjust-controls").forEach(function (controls) {
+        controls.classList.toggle("d-none", !isOverviewView);
+    });
     updateEngineViewModeButton();
 
     if (isDetailsView) {
@@ -1313,6 +1342,90 @@ function setPerformanceSubview(section, subview) {
         const command = new Command("performanceRequest", { teamID: teamSelected });
         command.execute();
     }
+}
+
+function syncOverviewAdjustControlsWithMode() {
+    document.querySelectorAll("#teamsDiv .team-performance").forEach(function (teamElem) {
+        const bar = teamElem.querySelector(".performance-bar-progress");
+        const input = teamElem.querySelector(".team-overall-adjust-input");
+        if (!bar || !input) return;
+        input.value = getBarDatasetValue(bar, "overall").toFixed(2);
+    });
+}
+
+function sendOverallAdjustCommand(teamElem, targetValue) {
+    const teamID = teamElem.dataset.teamid;
+    const teamName = teamElem.dataset.teamname;
+    const command = new Command("editTargetOverall", {
+        teamID: teamID,
+        teamName: teamName,
+        targetOverall: targetValue,
+        mode: performanceDetailsMode
+    });
+    command.execute();
+}
+
+function changeTeamOverallFromControl(teamElem, delta) {
+    const input = teamElem.querySelector(".team-overall-adjust-input");
+    if (!input) return;
+    let target = Number(input.value || 0);
+    target = target + delta;
+    if (target < 0) target = 0;
+    if (target > 100) target = 100;
+    input.value = target.toFixed(2);
+    setTeamBarValue(teamElem, performanceDetailsMode, target);
+    sendOverallAdjustCommand(teamElem, target);
+}
+
+function setupOverviewAdjustControls() {
+    document.querySelectorAll("#teamsDiv .team-performance").forEach(function (teamElem) {
+        const title = teamElem.querySelector(".team-title");
+        if (!title || title.querySelector(".team-overall-adjust-controls")) return;
+
+        const controls = document.createElement("span");
+        controls.classList.add("team-overall-adjust-controls", "d-none");
+
+        const less = document.createElement("i");
+        less.classList.add("bi", "bi-dash", "new-augment-button", "transparent");
+
+        const value = document.createElement("input");
+        value.type = "text";
+        value.classList.add("team-overall-adjust-input", "custom-input-number");
+        value.value = "0.00";
+
+        const plus = document.createElement("i");
+        plus.classList.add("bi", "bi-plus", "new-augment-button", "transparent");
+
+        controls.appendChild(less);
+        controls.appendChild(value);
+        controls.appendChild(plus);
+        title.insertBefore(controls, title.querySelector(".team-title-value"));
+
+        less.addEventListener("click", function (event) {
+            event.stopPropagation();
+            changeTeamOverallFromControl(teamElem, -overallAdjustStep);
+        });
+
+        plus.addEventListener("click", function (event) {
+            event.stopPropagation();
+            changeTeamOverallFromControl(teamElem, overallAdjustStep);
+        });
+
+        value.addEventListener("click", function (event) {
+            event.stopPropagation();
+        });
+
+        value.addEventListener("change", function (event) {
+            event.stopPropagation();
+            let target = Number(value.value || 0);
+            if (target < 0) target = 0;
+            if (target > 100) target = 100;
+            value.value = target.toFixed(2);
+            setTeamBarValue(teamElem, performanceDetailsMode, target);
+            sendOverallAdjustCommand(teamElem, target);
+        });
+    });
+    syncOverviewAdjustControlsWithMode();
 }
 
 function getEngineConditionItemLabel(name) {
@@ -2132,7 +2245,6 @@ function createPerformanceChart(labelsArray) {
         }
     );
 }
-
 
 
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -11508,6 +11508,20 @@ input[type='number'] {
   transition: color 0.15s;
 }
 
+.team-overall-adjust-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.team-overall-adjust-input {
+  width: 54px;
+  text-align: center;
+  font-size: 12px;
+  padding: 0;
+  margin: 0;
+}
+
 .car:hover .main-car,
 .team:hover .main-car {
   border-left: 2px solid var(--white-general);


### PR DESCRIPTION
### Motivation
- Provide a way to adjust a team's overall metric (performance/expertise/nextSeasonCar) to a target value programmatically. 
- Expose the adjustment as a worker command so the UI can request balancing a team's overall without manual per-stat edits.

### Description
- Added scaling utilities and `adjustTeamOverallToTarget` in `carAnalysisUtils.js` which compute and iteratively apply a multiplicative factor to part stat unit values and update performance/expertise/next-season car data via `overwritePerformanceTeam`, `updateTeamExpertise`, or `updateTeamNextSeasonExpertise` accordingly. 
- Implemented helper functions `getOverallByMode`, `cloneStatsDict`, `scaleStatsDictUnitValues`, `buildPartTypeStats`, and `buildPerformancePayload` to support the scaling and payload construction. 
- Wired a new worker command `editTargetOverall` in `worker.js` that calls `adjustTeamOverallToTarget` and re-posts refreshed performance/attributes payloads to the frontend. 
- Added overview controls in `performance.js` to adjust a team's overall from the UI, including input/plus/minus controls, input syncing, dataset updates, command sending (`editTargetOverall`), and initialization via `setupOverviewAdjustControls`. 
- Included minimal styling for the new overview controls in `styles.css`.

### Testing
- Built the project and ran the existing automated test suite (`npm run build` and `npm test`) after the changes and the run completed successfully. 
- Exercised the new worker command path by invoking `editTargetOverall` in the UI and verified the worker posts updated performance and attributes payloads (automated integration checks passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c259fafd2483328a48ccfea8924658)