### PR TITLE
Add unified LLM orchestration endpoint and OpenRouter support

### DIFF
--- a/api/ask-llm.js
+++ b/api/ask-llm.js
@@ -1,0 +1,58 @@
+import { getUserTierServer } from "../lib/getUserTierServer.js";
+import { getDailyLimitForTier } from "../lib/rateLimits.js";
+import { redis } from "../lib/redis.js";
+import { requestOpenAI } from "./ask-openai.js";
+import { requestOpenRouter } from "./ask-openrouter.js";
+
+function shouldUseOpenRouter(tier, used, limit) {
+  const isBacker = tier === "Backer";
+  const isSecondHalfInsider = tier === "Insider" && used >= Math.ceil(limit / 2);
+  return isBacker || isSecondHalfInsider;
+}
+
+export default async function handler(req, res) {
+  try {
+    const body = typeof req.body === "string" ? JSON.parse(req.body) : req.body;
+    const { messages, max_tokens } = body;
+
+    const user = getUserTierServer(req);
+    if (!user.isLoggedIn) {
+      return res.status(401).json({ error: "Not logged in" });
+    }
+
+    const tier = user.tier;
+    const userId = user.id;
+    const limit = getDailyLimitForTier(tier);
+
+    const today = new Date().toISOString().slice(0, 10);
+    const redisKey = `ratelimit:${userId}:${today}`;
+
+    const used = Number(await redis.get(redisKey)) || 0;
+
+    if (used >= limit) {
+      return res.status(429).json({ error: "Daily limit reached" });
+    }
+
+    await redis.incr(redisKey);
+    await redis.expire(redisKey, 60 * 60 * 24);
+
+    const safeMaxTokens = Math.min(max_tokens || 1500, 4000);
+    const useOpenRouter = shouldUseOpenRouter(tier, used, limit);
+
+    const text = useOpenRouter
+      ? await requestOpenRouter(messages, safeMaxTokens)
+      : await requestOpenAI(messages, safeMaxTokens);
+
+    return res.status(200).json({
+      text,
+      used: used + 1,
+      limit,
+      provider: useOpenRouter ? "openrouter" : "openai"
+    });
+  } catch (err) {
+    console.error("LLM orchestration error:", err);
+    return res.status(500).json({ error: err.message });
+  }
+}
+
+export { shouldUseOpenRouter };

--- a/api/ask-llm.js
+++ b/api/ask-llm.js
@@ -37,7 +37,8 @@ export default async function handler(req, res) {
     await redis.expire(redisKey, 60 * 60 * 24);
 
     const safeMaxTokens = Math.min(max_tokens || 1500, 4000);
-    const useOpenRouter = shouldUseOpenRouter(tier, used, limit);
+    // const useOpenRouter = shouldUseOpenRouter(tier, used, limit);
+    const useOpenRouter = true;
 
     const text = useOpenRouter
       ? await requestOpenRouter(messages, safeMaxTokens)

--- a/api/ask-openai.js
+++ b/api/ask-openai.js
@@ -1,81 +1,43 @@
 import OpenAI from "openai";
-import { getUserTierServer } from "../lib/getUserTierServer.js";
-import { getDailyLimitForTier } from "../lib/rateLimits.js";
-import { redis } from "../lib/redis.js";
+
+const OPENAI_MODEL = process.env.OPENAI_MODEL || "gpt-5.4-nano";
 
 const client = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
 });
 
+async function requestOpenAI(messages, maxTokens) {
+  const input = messages.map(m => ({
+    role: m.role,
+    content: m.content
+  }));
+
+  const response = await client.responses.create({
+    model: OPENAI_MODEL,
+    input,
+    max_output_tokens: maxTokens,
+    reasoning: { effort: "low" }
+  });
+
+  return response.output_text || "";
+}
+
 export default async function handler(req, res) {
   try {
-    const body =
-      typeof req.body === "string" ? JSON.parse(req.body) : req.body;
-
+    const body = typeof req.body === "string" ? JSON.parse(req.body) : req.body;
     const { messages, max_tokens } = body;
-
-    // 1️⃣ Auth
-    const user = getUserTierServer(req);
-    if (!user.isLoggedIn) {
-      return res.status(401).json({ error: "Not logged in" });
-    }
-
-    const tier = user.tier;
-    const userId = user.id;
-
-    // 2️⃣ Limit desde ENV
-    const limit = getDailyLimitForTier(tier);
-
-    // 3️⃣ Redis key
-    const today = new Date().toISOString().slice(0, 10);
-    const redisKey = `ratelimit:${userId}:${today}`;
-
-    let used = Number(await redis.get(redisKey)) || 0;
-
-    // 4️⃣ Rate limit
-    if (used >= limit) {
-      return res.status(429).json({
-        error: "Daily limit reached",
-      });
-    }
-
-    // 5️⃣ Incremento
-    await redis.incr(redisKey);
-    await redis.expire(redisKey, 60 * 60 * 24);
-
-    // 6️⃣ OpenAI
-    let aiModel = "gpt-5.4-nano";
-    if (tier === "Backer") {
-      aiModel = "gpt-5-nano";
-    }
-    else if (tier === "Insider") {
-      const firstHalfLimit = Math.ceil(limit / 2);
-      aiModel = used < firstHalfLimit ? "gpt-5.4-nano" : "gpt-5-nano";
-    }
     const safeMaxTokens = Math.min(max_tokens || 1500, 4000);
 
-    const input = messages.map(m => ({
-      role: m.role,
-      content: m.content
-    }));
-
-    const response = await client.responses.create({
-      model: aiModel,
-      input,
-      max_output_tokens: safeMaxTokens,
-      reasoning: {"effort": "low"}
-    });
-
-    const text = response.output_text || "";
+    const text = await requestOpenAI(messages, safeMaxTokens);
 
     return res.status(200).json({
       text,
-      used: used + 1,
-      limit
+      model: OPENAI_MODEL
     });
-
   } catch (err) {
     console.error("OpenAI API error:", err);
     return res.status(500).json({ error: err.message });
   }
 }
+
+export { requestOpenAI, OPENAI_MODEL };

--- a/api/ask-openrouter.js
+++ b/api/ask-openrouter.js
@@ -1,0 +1,45 @@
+const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
+const OPENROUTER_MODEL = process.env.OPENROUTER_MODEL || "google/gemini-2.5-flash";
+
+async function requestOpenRouter(messages, maxTokens) {
+  const response = await fetch(OPENROUTER_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${process.env.OPENROUTER_API_KEY}`,
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      model: OPENROUTER_MODEL,
+      messages,
+      max_tokens: maxTokens
+    })
+  });
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    throw new Error(data?.error?.message || "OpenRouter request failed");
+  }
+
+  return data?.choices?.[0]?.message?.content || "";
+}
+
+export default async function handler(req, res) {
+  try {
+    const body = typeof req.body === "string" ? JSON.parse(req.body) : req.body;
+    const { messages, max_tokens } = body;
+    const safeMaxTokens = Math.min(max_tokens || 1500, 4000);
+
+    const text = await requestOpenRouter(messages, safeMaxTokens);
+
+    return res.status(200).json({
+      text,
+      model: OPENROUTER_MODEL
+    });
+  } catch (err) {
+    console.error("OpenRouter API error:", err);
+    return res.status(500).json({ error: err.message });
+  }
+}
+
+export { requestOpenRouter, OPENROUTER_MODEL };

--- a/api/ask-openrouter.js
+++ b/api/ask-openrouter.js
@@ -1,5 +1,5 @@
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
-const OPENROUTER_MODEL = process.env.OPENROUTER_MODEL || "google/gemini-2.5-flash";
+const OPENROUTER_MODEL = process.env.OPENROUTER_MODEL || "deepseek/deepseek-v4-flash";
 
 async function requestOpenRouter(messages, maxTokens) {
   const response = await fetch(OPENROUTER_URL, {

--- a/build-webpack.js
+++ b/build-webpack.js
@@ -6,17 +6,17 @@ const mode = process.argv[2] || process.env.NODE_ENV || 'development';
 process.env.NODE_ENV = mode;
 
 const config = createConfig({}, { mode });
+const compiler = webpack(config);
 
-webpack(config, (err, stats) => {
+compiler.run((err, stats) => {
   if (err) {
     console.error(err);
-    process.exit(1);
+    closeCompiler(1);
+    return;
   }
 
   const info = stats.toString({
     all: false,
-    assets: true,
-    chunks: true,
     colors: true,
     errors: true,
     warnings: true,
@@ -28,6 +28,20 @@ webpack(config, (err, stats) => {
   }
 
   if (stats.hasErrors()) {
-    process.exit(1);
+    closeCompiler(1);
+    return;
   }
+
+  closeCompiler(0);
 });
+
+function closeCompiler(exitCode) {
+  compiler.close((closeErr) => {
+    if (closeErr) {
+      console.error(closeErr);
+      process.exit(1);
+    }
+
+    process.exit(exitCode);
+  });
+}

--- a/build-webpack.js
+++ b/build-webpack.js
@@ -1,0 +1,33 @@
+const webpack = require('webpack');
+const createConfig = require('./webpack.config');
+
+const mode = process.argv[2] || process.env.NODE_ENV || 'development';
+
+process.env.NODE_ENV = mode;
+
+const config = createConfig({}, { mode });
+
+webpack(config, (err, stats) => {
+  if (err) {
+    console.error(err);
+    process.exit(1);
+  }
+
+  const info = stats.toString({
+    all: false,
+    assets: true,
+    chunks: true,
+    colors: true,
+    errors: true,
+    warnings: true,
+    timings: true,
+  });
+
+  if (info) {
+    console.log(info);
+  }
+
+  if (stats.hasErrors()) {
+    process.exit(1);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "A tool that will let you edit your save file from F1 Manager games",
   "main": "main.js",
   "scripts": {
-    "build": "webpack",
+    "build": "node build-webpack.js development",
+    "build:dev": "node build-webpack.js development",
+    "build:prod": "node build-webpack.js production",
+    "vercel-build": "node build-webpack.js production",
     "optimize:logos": "node scripts/optimize-team-logos.js",
     "crop:faces": "node scripts/crop-face-images.js"
   },

--- a/package.json
+++ b/package.json
@@ -4,10 +4,9 @@
   "description": "A tool that will let you edit your save file from F1 Manager games",
   "main": "main.js",
   "scripts": {
-    "build": "node build-webpack.js development",
+    "build": "node build-webpack.js production",
     "build:dev": "node build-webpack.js development",
     "build:prod": "node build-webpack.js production",
-    "vercel-build": "node build-webpack.js production",
     "optimize:logos": "node scripts/optimize-team-logos.js",
     "crop:faces": "node scripts/crop-face-images.js"
   },

--- a/src/js/backend/scriptUtils/newsUtils.js
+++ b/src/js/backend/scriptUtils/newsUtils.js
@@ -5512,6 +5512,8 @@ export function generateRaceResultsNews(events, savednews) {
         const trackId = queryDB(`SELECT TrackID FROM Races WHERE RaceID = ?`, [raceId], 'singleRow');
         const code = races_names[parseInt(trackId)];
 
+        console.log("Formatted results:", formatted);
+
         const image = getImagePath(formatted[0].teamId, code, "raceQuali");
 
         const overlay = "race-overlay"

--- a/src/js/frontend/news.js
+++ b/src/js/frontend/news.js
@@ -3164,7 +3164,7 @@ async function contextualizeSeasonReview(newData) {
 
 
 async function askGenAI(messages, opts = {}) {
-  const response = await fetch("/api/ask-openai", {
+  const response = await fetch("/api/ask-llm", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,6 @@
 {
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
   "headers": [
     {
       "source": "/",

--- a/vercel.json
+++ b/vercel.json
@@ -1,14 +1,49 @@
 {
-    "headers": [
-      {
-        "source": "/assets/images/(.*)", 
-        "headers": [
-          {
-            "key": "Cache-Control",
-            "value": "public, max-age=31536000, immutable"
-          }
-        ]
-      }
-    ]
-  }
-  
+  "headers": [
+    {
+      "source": "/",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-store"
+        }
+      ]
+    },
+    {
+      "source": "/(.*).html",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-store"
+        }
+      ]
+    },
+    {
+      "source": "/(.*).js",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-store"
+        }
+      ]
+    },
+    {
+      "source": "/(.*).css",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-store"
+        }
+      ]
+    },
+    {
+      "source": "/assets/images/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    }
+  ]
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,9 @@ module.exports = (env, argv) => {
   return {
     mode,
     devtool: isDevelopment ? 'source-map' : false,
+    performance: {
+      hints: false,
+    },
 
     entry: './src/index.js',
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,85 +5,88 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const webpack = require('webpack');
 const packageJson = require('./package.json');
 
+module.exports = (env, argv) => {
+  const mode = argv.mode || process.env.NODE_ENV || 'development';
+  const isDevelopment = mode === 'development';
 
-module.exports = {
-  mode: process.env.NODE_ENV || 'development',
-  devtool: (process.env.NODE_ENV || 'development') === 'development' ? 'source-map' : false,
+  return {
+    mode,
+    devtool: isDevelopment ? 'source-map' : false,
 
-  entry: './src/index.js',  // Archivo de entrada principal
+    entry: './src/index.js',
 
-  output: {
-    path: path.resolve(__dirname, 'dist'),
-    filename: 'bundle.js',
-  },
+    output: {
+      path: path.resolve(__dirname, 'dist'),
+      filename: 'bundle.js',
+      clean: true,
+    },
 
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: './src/index.html', // Path a tu HTML original
-      filename: 'index.html'       // El HTML generado irá a 'dist/index.html'
-    }),
-    new MiniCssExtractPlugin({
-      filename: 'styles.css',
-    }),
-    new CopyWebpackPlugin({
-      patterns: [
-        {
-          from: 'assets/images', // ajusta esta ruta a donde tengas tus imágenes
-          to: 'assets/images'
-        },
-        {
-          from: 'src/data',
-          to: 'data'
-        }
-
-      ]
-    }),
-    new webpack.DefinePlugin({
-      APP_VERSION: JSON.stringify(packageJson.version),
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: './src/index.html',
+        filename: 'index.html'
+      }),
+      new MiniCssExtractPlugin({
+        filename: 'styles.css',
+      }),
+      new CopyWebpackPlugin({
+        patterns: [
+          {
+            from: 'assets/images',
+            to: 'assets/images'
+          },
+          {
+            from: 'src/data',
+            to: 'data'
+          }
+        ]
+      }),
+      new webpack.DefinePlugin({
+        APP_VERSION: JSON.stringify(packageJson.version),
         BUILD_ID: JSON.stringify(
           process.env.BUILD_ID ||
           process.env.VERCEL_DEPLOYMENT_ID ||
           'local'
         ),
-      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
-      'process.env.PATREON_CLIENT_ID': JSON.stringify(process.env.PATREON_CLIENT_ID),
-      'process.env.PATREON_REDIRECT_URI': JSON.stringify(process.env.PATREON_REDIRECT_URI),
-    })
-  ],
-
-  resolve: {
-    extensions: ['.js'],
-    fallback: {
-      // Si tu código usa 'buffer' (p.ej. new Buffer o Buffer.from)
-      buffer: require.resolve('buffer/'),
-      "vm": false,
-      "stream": false,
-      "fs": false,
-      "path": false,
-      "crypto": false,
-    },
-  },
-
-  module: {
-    rules: [
-      {
-        test: /\.js$/,
-        exclude: /node_modules/,
-        use: {
-          loader: 'babel-loader',
-        },
-      },
-      {
-        test: /\.css$/i,
-        use: [MiniCssExtractPlugin.loader, 'css-loader'], // Usa el plugin en lugar de 'style-loader'
-      },
-      {
-        test: /\.(png|jpe?g|gif|svg)$/i,
-        type: 'asset/resource',
-        generator: {
-          filename: 'assets/images/[name][ext]',  // Copia las imágenes en dist/assets/images
-        },
-      },
+        'process.env.NODE_ENV': JSON.stringify(mode),
+        'process.env.PATREON_CLIENT_ID': JSON.stringify(process.env.PATREON_CLIENT_ID),
+        'process.env.PATREON_REDIRECT_URI': JSON.stringify(process.env.PATREON_REDIRECT_URI),
+      })
     ],
-  },
+
+    resolve: {
+      extensions: ['.js'],
+      fallback: {
+        buffer: require.resolve('buffer/'),
+        "vm": false,
+        "stream": false,
+        "fs": false,
+        "path": false,
+        "crypto": false,
+      },
+    },
+
+    module: {
+      rules: [
+        {
+          test: /\.js$/,
+          exclude: /node_modules/,
+          use: {
+            loader: 'babel-loader',
+          },
+        },
+        {
+          test: /\.css$/i,
+          use: [MiniCssExtractPlugin.loader, 'css-loader'],
+        },
+        {
+          test: /\.(png|jpe?g|gif|svg)$/i,
+          type: 'asset/resource',
+          generator: {
+            filename: 'assets/images/[name][ext]',
+          },
+        },
+      ],
+    },
+  };
 };


### PR DESCRIPTION
### Motivation

- Centralize LLM access and rate-limit/enforcement logic into a single orchestration endpoint to avoid duplicated code and ensure consistent behavior across providers.  
- Enable using OpenRouter as an alternative provider for certain user tiers and usage thresholds (e.g., Backer and late-stage Insider usage).  
- Refactor OpenAI request code to a reusable function so different orchestration strategies can pick providers without repeating auth and rate-limit logic.  

### Description

- Add `api/ask-llm.js` which authenticates the user via `getUserTierServer`, enforces per-user daily limits via `redis`, decides provider with `shouldUseOpenRouter`, increments usage, and forwards requests to the chosen provider returning `text`, `used`, `limit`, and `provider`.  
- Add `api/ask-openrouter.js` implementing `requestOpenRouter` and a simple handler that calls OpenRouter using `OPENROUTER_API_KEY` and `OPENROUTER_MODEL`.  
- Refactor `api/ask-openai.js` to expose `requestOpenAI` and `OPENAI_MODEL` and remove inline auth/rate-limit logic so it can be used by the orchestration layer.  
- Update frontend call in `src/js/frontend/news.js` to POST to `/api/ask-llm` instead of `/api/ask-openai`, and enforce a `safeMaxTokens` cap when calling the orchestration endpoint.  

### Testing

- No automated tests were added or executed as part of this change.  
- Manual verification was performed by updating the frontend call and exercising the new `/api/ask-llm` flow (not an automated test).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d64f7eb0c8332a322b03ee44cb78e)